### PR TITLE
[202205-msft] Added change to not return error for Sonic t2/spine-router role when config bgp shutdown/startup is given

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -3619,8 +3619,12 @@ def neighbor(ipaddr_or_hostname, verbose):
         if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'down', verbose):
             found_neighbor = True
 
+    device_metadata = config_db.get_entry('DEVICE_METADATA', 'localhost')
     if not found_neighbor:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+        if device_metadata['type'] == 'SpineRouter':
+            click.echo("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+        else:
+            click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
 
 @bgp.group(cls=clicommon.AbbreviationGroup)
 def startup():
@@ -3674,8 +3678,12 @@ def neighbor(ipaddr_or_hostname, verbose):
         if _change_bgp_session_status(config_db, ipaddr_or_hostname, 'up', verbose):
             found_neighbor = True
 
+    device_metadata = config_db.get_entry('DEVICE_METADATA', 'localhost')
     if not found_neighbor:
-        click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+        if device_metadata['type'] == 'SpineRouter':
+            click.echo("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
+        else:
+            click.get_current_context().fail("Could not locate neighbor '{}'".format(ipaddr_or_hostname))
 
 #
 # 'remove' subgroup ('config bgp remove ...')


### PR DESCRIPTION
What I did:

Added change to not return error for Sonic t2/spine-router role when config bgp shutdown/startup is given

Why i did:
 This is done because for T2 BGP neighbors are present across different LC's so it's possible when command is executed that neighbor might not be present on that LC. In this case instead of returning error we log the message and return success

