### PR TITLE
[show] multi-asic show running test residue (#3198)

### DIFF
--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -100,6 +100,7 @@ class TestShowRunAllCommandsMasic(object):
         bgp_util.run_bgp_command = cls._old_run_bgp_command
         os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
         os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
         # change back to single asic config
         from .mock_tables import dbconnector
         from .mock_tables import mock_single_asic


### PR DESCRIPTION
#### What I did
Cherry-pick fix for the TPID test breakage introduced by https://github.com/Azure/sonic-utilities.msft/pull/45

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

