### PR TITLE
T2-VOQ-VS: Modified exception handling due to new sonic_platform pack…

### DIFF
--- a/utilities_common/platform_sfputil_helper.py
+++ b/utilities_common/platform_sfputil_helper.py
@@ -121,10 +121,10 @@ def is_rj45_port(port_name):
         if not platform_sfp_base:
             import sonic_platform_base
             platform_sfp_base = sonic_platform_base.sfp_base.SfpBase
-    except ModuleNotFoundError as e:
+    except (ModuleNotFoundError, FileNotFoundError) as e:
         # This method is referenced by intfutil which is called on vs image
-        # However, there is no platform API supported on vs image
-        # So False is returned in such case
+        # sonic_platform API support is added for vs image(required for chassis), it expects a metadata file, which
+        # wont be available on vs pizzabox duts, So False is returned(if either ModuleNotFound or FileNotFound)
         return False
 
     if platform_chassis and platform_sfp_base:


### PR DESCRIPTION
…age support for VS (#3250)

### What I did
For T2-Chassis VS support, we are adding new sonic_platform package for vs platforms. Please refer https://github.com/sonic-net/sonic-buildimage/pull/18512 for more details. Due to this new platform package, need to modify excpetion handling as now the Module would be found, but the metadata file will not be found for pizzabox vs platforms.

This is to pick up this PR from public master: https://github.com/sonic-net/sonic-utilities/pull/3250

#### How I did it
Modified the exception handling logic.
MSFT ADO: 27414904

#### How to verify it
Bring up vms-kvm-t0 topology. ran show interface status. The output is proper.

PS: the Main PR(https://github.com/sonic-net/sonic-buildimage/pull/18512) is dependent on this PR to be merged in first.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

