### PR TITLE
[chassis][midplane] Add notification to Supervisor when LC is gracefu…

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -186,6 +186,25 @@ function parse_options()
     done
 }
 
+function linecard_reboot_notify_supervisor()
+{
+    is_linecard=$(python3 -c 'from sonic_py_common import device_info; print("True") if device_info.is_chassis() == True and device_info.is_supervisor() == False else print("False")')
+    if [ $is_linecard == "True" ]; then
+        key=$(sonic-db-cli STATE_DB keys "CHASSIS_MODULE_TABLE|LINE-CARD*")
+        status=$?
+        if [ $status -eq 0 ]; then
+            module="${key#CHASSIS_MODULE_TABLE}"
+            if [ ! -z module ]; then
+                sonic-db-cli CHASSIS_STATE_DB hset "CHASSIS_MODULE_REBOOT_INFO_TABLE${module}" "reboot" "expected"
+                status=$?
+                if [ $status -ne 0 ]; then
+                    debug "Failed to notify Supervisor: Linecard reboot is expected"
+                fi
+            fi
+        fi
+    fi
+}
+
 parse_options $@
 
 # Exit if not superuser
@@ -203,6 +222,9 @@ reboot_pre_check
 
 # Tag remotely deployed images as local
 tag_images
+
+# Linecard reboot notify supervisor
+linecard_reboot_notify_supervisor
 
 # Stop SONiC services gracefully.
 stop_sonic_services


### PR DESCRIPTION
…l reboot (#3292)

* [chassis][midplane] Add notification to Supervisor when LC is graceful reboot

* Address review comment by adding log message when failed to create wentry in CHASSIS_STATE_DB

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

