### PR TITLE
Fix test_config_reload_untriggered_timer

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -130,6 +130,10 @@ Restarting SONiC target ...
 Reloading Monit configuration ...
 """
 
+reload_config_with_untriggered_timer_output="""\
+Relevant services are not up. Retry later or use -f to avoid system checks
+"""
+
 config_temp = {
         "scope": {
             "ACL_TABLE": {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

This fixed the UT error which introduced by this PR: https://github.com/sonic-net/sonic-utilities.msft/pull/77

![image](https://github.com/sonic-net/sonic-utilities.msft/assets/147451452/e92c84f2-3ab3-45da-a999-649b888f2822)


#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

