### PR TITLE
Change the default behavior of show ip bgp network (#3447)

### DIFF
--- a/tests/bgp_commands_input/bgp_network_test_vector.py
+++ b/tests/bgp_commands_input/bgp_network_test_vector.py
@@ -595,10 +595,10 @@ testData = {
         'rc': 0,
         'rc_output': bgp_v6_network_longer_prefixes
     },
-    'bgp_v4_network_multi_asic': {
+    'bgp_v4_network_default_multi_asic': {
         'args': [],
-        'rc': 2,
-        'rc_err_msg': multi_asic_bgp_network_err
+        'rc': 0,
+        'rc_output': bgp_v4_network_all_asic
     },
     'bgp_v4_network_asic0': {
         'args': ['-nasic0'],

--- a/tests/remote_show_test.py
+++ b/tests/remote_show_test.py
@@ -31,6 +31,7 @@ class TestRexecBgp(object):
         pass
 
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("sys.argv", ["show", "ip", "bgp", "summary"])
     def test_show_ip_bgp_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()
@@ -44,6 +45,7 @@ class TestRexecBgp(object):
         assert MULTI_LC_REXEC_OUTPUT == result.output
 
     @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("sys.argv", ["show", "ip", "bgp", "summary"])
     def test_show_ip_bgp_error_rexec(self, setup_bgp_commands):
         show = setup_bgp_commands
         runner = CliRunner()
@@ -55,3 +57,17 @@ class TestRexecBgp(object):
         subprocess.run = _old_subprocess_run
         assert result.exit_code == 1
         assert MULTI_LC_ERR_OUTPUT == result.output
+
+    @mock.patch("sonic_py_common.device_info.is_supervisor", mock.MagicMock(return_value=True))
+    @mock.patch("sys.argv", ["show", "ip", "bgp", "network", "10.0.0.0/24"])
+    def test_show_ip_bgp_network_rexec(self, setup_bgp_commands):
+        show = setup_bgp_commands
+        runner = CliRunner()
+
+        _old_subprocess_run = subprocess.run
+        subprocess.run = mock_rexec_command
+        result = runner.invoke(show.cli.commands["ip"].commands["bgp"], args=["network", "10.0.0.0/24"])
+        print(result.output)
+        subprocess.run = _old_subprocess_run
+        assert result.exit_code == 0
+        assert MULTI_LC_REXEC_OUTPUT == result.output

--- a/tests/show_bgp_network_test.py
+++ b/tests/show_bgp_network_test.py
@@ -78,7 +78,7 @@ class TestMultiAsicBgpNetwork(object):
 
     @pytest.mark.parametrize(
         'setup_multi_asic_bgp_instance, test_vector',
-        [('bgp_v4_network', 'bgp_v4_network_multi_asic'),
+        [('bgp_v4_network_all_asic', 'bgp_v4_network_default_multi_asic'),
          ('bgp_v6_network', 'bgp_v6_network_multi_asic'),
          ('bgp_v4_network_asic0', 'bgp_v4_network_asic0'),
          ('bgp_v4_network_ip_address_asic0', 'bgp_v4_network_ip_address_asic0'),


### PR DESCRIPTION
* show/bgp_frr_v4.py: change the default behavior of "show ip bgp network"

- after change, show ip bgp network will have "all" as the default value of namespace option
- after change, ip-address/ip-prefix is a required argument when executing show ip bgp network on a chassis supervisor

* tests/remote_show_test.py update unit tests to comply with the new behaviors

* tests/show_bgp_network_test.py: update a test vector to make it comply with the new default behavior

* tests/bgp_commands_input/bgp_network_test_vector.py: update a test vector to comply with the new default behavior

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

