### PR TITLE
[chassis] Modify the show ip route to hide the Ethernet-IB port in the ouput(#3537)

### DIFF
--- a/show/bgp_common.py
+++ b/show/bgp_common.py
@@ -3,7 +3,7 @@ import ipaddress
 import json
 
 import utilities_common.multi_asic as multi_asic_util
-from sonic_py_common import multi_asic
+from sonic_py_common import device_info, multi_asic
 from utilities_common import constants
 
 '''
@@ -60,10 +60,12 @@ def get_nexthop_info_str(nxhp_info, filterByIp):
         else:
             str_2_return = " via {},".format(nxhp_info['ip'])
         if "interfaceName" in nxhp_info:
+            intfs = nxhp_info['interfaceName']
             if filterByIp:
-                str_2_return += ", via {}".format(nxhp_info['interfaceName'])
+                str_2_return += ", via {}".format(intfs)
             else:
-                str_2_return += " {},".format(nxhp_info['interfaceName'])
+                str_2_return += " {},".format(intfs)
+
     elif "directlyConnected" in nxhp_info:
         str_2_return = " is directly connected,"
         if "interfaceName" in nxhp_info:
@@ -80,10 +82,13 @@ def get_nexthop_info_str(nxhp_info, filterByIp):
         str_2_return += "(vrf {}, {},".format(nxhp_info['vrf'], nxhp_info['interfaceName'])
     if "active" not in nxhp_info:
         str_2_return += " inactive"
+    if "recursive" in nxhp_info:
+        if device_info.is_voq_chassis():
+            str_2_return = "  " + str_2_return + " recursive via iBGP"
+        else:
+            str_2_return += " (recursive)"
     if "onLink" in nxhp_info:
         str_2_return += " onlink"
-    if "recursive" in nxhp_info:
-        str_2_return += " (recursive)"
     if "source" in nxhp_info:
         str_2_return += ", src {}".format(nxhp_info['source'])
     if "labels" in nxhp_info:
@@ -220,6 +225,12 @@ def merge_to_combined_route(combined_route, route, new_info_l):
                                     if nh['interfaceName'] == combined_route[route][j]['nexthops'][y]['interfaceName']:
                                         found = True
                                         break
+                                if device_info.is_voq_chassis():
+                                    if nh['ip'] == combined_route[route][j]['nexthops'][y]['ip']:
+                                        if 'interfaceName' not in combined_route[route][j]['nexthops'][y]:
+                                            combined_route[route][j]['nexthops'][y] = nh
+                                        found = True
+                                        break
                                 elif "active" not in nh and "active" not in combined_route[route][j]['nexthops'][y]:
                                     if nh['ip'] == combined_route[route][j]['nexthops'][y]['ip']:
                                         found = True
@@ -253,7 +264,7 @@ def process_route_info(route_info, device, filter_back_end, print_ns_str, asic_c
             while len(new_info['nexthops']):
                 nh = new_info['nexthops'].pop()
                 if filter_back_end and back_end_intf_set != None and "interfaceName" in nh:
-                    if nh['interfaceName'] in back_end_intf_set:
+                    if nh['interfaceName'] in back_end_intf_set or nh['interfaceName'].startswith('Ethernet-IB'):
                         del_cnt += 1
                     else:
                         new_nhop_l.append(copy.deepcopy(nh))
@@ -327,6 +338,7 @@ def show_routes(args, namespace, display, verbose, ipver):
             if display not in ['frontend', 'all']:
                 print("dislay option '{}' is not a valid option.".format(display))
                 return
+
     device = multi_asic_util.MultiAsic(display, namespace)
     arg_strg = ""
     found_json = 0
@@ -376,7 +388,6 @@ def show_routes(args, namespace, display, verbose, ipver):
         # Need to add "ns" to form bgpX so it is sent to the correct bgpX docker to handle the request
         cmd = "show {} route {}".format(ipver, arg_strg)
         output = bgp_util.run_bgp_show_command(cmd, ns)
-
         # in case no output or something went wrong with user specified cmd argument(s) error it out
         # error from FRR always start with character "%"
         if output == "":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,7 +187,11 @@ def setup_single_bgp_instance(request):
     elif request.param == 'ipv6_route':
         bgp_mocked_json = 'ipv6_route.json'
     elif request.param == 'ip_special_route':
-        bgp_mocked_json = 'ip_special_route.json'    
+        bgp_mocked_json = 'ip_special_route.json'
+    elif request.param == 'ip_route_lc':
+        bgp_mocked_json = 'ip_route_lc.json'
+    elif request.param == 'ip_route_remote_lc':
+        bgp_mocked_json = 'ip_route_remote_lc.json'
     else:
         bgp_mocked_json = os.path.join(
             test_path, 'mock_tables', 'dummy.json')
@@ -233,7 +237,8 @@ def setup_single_bgp_instance(request):
     _old_run_bgp_command = bgp_util.run_bgp_command
     if any([request.param == 'ip_route',
             request.param == 'ip_specific_route', request.param == 'ip_special_route',
-            request.param == 'ipv6_route', request.param == 'ipv6_specific_route']):
+            request.param == 'ipv6_route', request.param == 'ipv6_specific_route',
+            request.param == 'ip_route_lc', request.param == 'ip_route_remote_lc']):
         bgp_util.run_bgp_command = mock.MagicMock(
             return_value=mock_run_bgp_route_command("", ""))
     elif request.param.startswith('ipv6_route_err'):
@@ -296,6 +301,12 @@ def setup_multi_asic_bgp_instance(request):
         request.param.startswith('bgp_v4_neighbor') or \
         request.param.startswith('bgp_v6_neighbor'):
         m_asic_json_file = request.param
+    elif request.param == 'ip_route_lc':
+        m_asic_json_file = 'ip_route_lc.json'
+    elif request.param == 'ip_route_remote_lc':
+        m_asic_json_file = 'ip_route_remote_lc.json'
+    elif request.param == 'ip_route_lc_2':
+        m_asic_json_file = 'ip_route_lc_2.json'
     else:
         m_asic_json_file = os.path.join(
             test_path, 'mock_tables', 'dummy.json')

--- a/tests/ip_show_routes_multi_asic_test.py
+++ b/tests/ip_show_routes_multi_asic_test.py
@@ -1,10 +1,11 @@
 import os
 from importlib import reload
-
 import pytest
+
 
 from . import show_ip_route_common
 from click.testing import CliRunner
+
 test_path = os.path.dirname(os.path.abspath(__file__))
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, "scripts")

--- a/tests/ip_show_routes_voq_chassis_test.py
+++ b/tests/ip_show_routes_voq_chassis_test.py
@@ -1,0 +1,112 @@
+import os
+from importlib import reload
+import pytest
+from unittest import mock
+
+import show.main as show
+from . import show_ip_route_common
+import utilities_common.multi_asic as multi_asic_util
+from click.testing import CliRunner
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+
+
+class TestMultiAsicVoqLcShowIpRouteDisplayAllCommands(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ["UTILITIES_UNIT_TESTING"] = "2"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+        from .mock_tables import mock_multi_asic
+        reload(mock_multi_asic)
+        from .mock_tables import dbconnector
+        dbconnector.load_namespace_config()
+
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
+                             ['ip_route_lc'], indirect=['setup_multi_asic_bgp_instance'])
+    @mock.patch("sonic_py_common.device_info.is_voq_chassis", mock.MagicMock(return_value=True))
+    def test_voq_chassis_lc(
+            self,
+            setup_ip_route_commands,
+            setup_multi_asic_bgp_instance):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["route"], ["-dfrontend"])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_ip_route_common.SHOW_IP_ROUTE_LC
+
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
+                             ['ip_route_remote_lc'], indirect=['setup_multi_asic_bgp_instance'])
+    @mock.patch("sonic_py_common.device_info.is_voq_chassis", mock.MagicMock(return_value=True))
+    def test_voq_chassis_remote_lc(
+            self,
+            setup_ip_route_commands,
+            setup_multi_asic_bgp_instance):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["route"], ["-dfrontend"])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_ip_route_common.SHOW_IP_ROUTE_REMOTE_LC
+
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
+                             ['ip_route_lc'], indirect=['setup_multi_asic_bgp_instance'])
+    @mock.patch("sonic_py_common.device_info.is_voq_chassis", mock.MagicMock(return_value=True))
+    def test_voq_chassis_lc_def_route(
+            self,
+            setup_ip_route_commands,
+            setup_multi_asic_bgp_instance):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["route"], ["0.0.0.0/0"])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_ip_route_common.SHOW_IP_ROUTE_LC_DEFAULT_ROUTE
+
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
+                             ['ip_route_remote_lc'], indirect=['setup_multi_asic_bgp_instance'])
+    @mock.patch("sonic_py_common.device_info.is_voq_chassis", mock.MagicMock(return_value=True))
+    def test_voq_chassis_remote_lc_default_route(
+            self,
+            setup_ip_route_commands,
+            setup_multi_asic_bgp_instance):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["route"], ["0.0.0.0/0"])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_ip_route_common.SHOW_IP_ROUTE_REMOTE_LC_DEFAULT_ROUTE
+
+    @pytest.mark.parametrize('setup_multi_asic_bgp_instance',
+                             ['ip_route_lc_2'], indirect=['setup_multi_asic_bgp_instance'])
+    @mock.patch("sonic_py_common.device_info.is_voq_chassis", mock.MagicMock(return_value=True))
+    @mock.patch.object(multi_asic_util.MultiAsic, "get_ns_list_based_on_options",
+                       mock.MagicMock(return_value=["asic0", "asic1"]))
+    def test_voq_chassis_lc_def_route_2(
+            self,
+            setup_ip_route_commands,
+            setup_multi_asic_bgp_instance):
+
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["ip"].commands["route"], ["0.0.0.0/0"])
+        print("{}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == show_ip_route_common.SHOW_IP_ROUTE_LC_DEFAULT_ROUTE_2
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+        from .mock_tables import mock_single_asic
+        reload(mock_single_asic)

--- a/tests/mock_tables/asic0/ip_route_lc.json
+++ b/tests/mock_tables/asic0/ip_route_lc.json
@@ -1,0 +1,66 @@
+{
+    "0.0.0.0/0": [
+        {
+            "prefix": "0.0.0.0/0",
+            "prefixLen": 0,
+            "protocol": "bgp",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 20,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 8,
+            "internalNextHopNum": 4,
+            "internalNextHopActiveNum": 4,
+            "nexthopGroupId": 566,
+            "installedNexthopGroupId": 566,
+            "uptime": "04w0d11h",
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "20.1.0.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 2,
+                    "interfaceName": "PortChannel1",
+                    "active": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "20.1.8.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 4,
+                    "interfaceName": "PortChannel5",
+                    "active": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "20.1.16.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 5,
+                    "interfaceName": "PortChannel9",
+                    "active": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "20.1.24.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 3,
+                    "interfaceName": "PortChannel13",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/mock_tables/asic0/ip_route_lc_2.json
+++ b/tests/mock_tables/asic0/ip_route_lc_2.json
@@ -1,0 +1,56 @@
+{
+    "0.0.0.0/0": [
+        {
+            "prefix": "0.0.0.0/0",
+            "prefixLen": 0,
+            "protocol": "bgp",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 20,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 3,
+            "internalNextHopActiveNum": 3,
+            "nexthopGroupId": 2122,
+            "installedNexthopGroupId": 2122,
+            "uptime": "01:01:51",
+            "nexthops": [
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.1",
+                    "afi": "ipv4",
+                    "interfaceIndex": 29,
+                    "interfaceName": "PortChannel102",
+                    "active": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "10.0.0.7",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "10.0.0.7",
+                    "afi": "ipv4",
+                    "interfaceIndex": 52,
+                    "interfaceName": "Ethernet-IB0",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/mock_tables/asic0/ip_route_remote_lc.json
+++ b/tests/mock_tables/asic0/ip_route_remote_lc.json
@@ -1,0 +1,106 @@
+{
+    "0.0.0.0/0": [
+        {
+            "prefix": "0.0.0.0/0",
+            "prefixLen": 0,
+            "protocol": "bgp",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 200,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 13,
+            "internalNextHopNum": 8,
+            "internalNextHopActiveNum": 8,
+            "nexthopGroupId": 465,
+            "installedNexthopGroupId": 465,
+            "uptime": "04w0d12h",
+            "nexthops": [
+                {
+                    "flags": 5,
+                    "ip": "20.1.0.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.0.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB0",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.8.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.8.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB0",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.16.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.16.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB0",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.24.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.24.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB0",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/mock_tables/asic1/ip_route_lc.json
+++ b/tests/mock_tables/asic1/ip_route_lc.json
@@ -1,0 +1,106 @@
+{
+    "0.0.0.0/0": [
+        {
+            "prefix": "0.0.0.0/0",
+            "prefixLen": 0,
+            "protocol": "bgp",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 200,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 13,
+            "internalNextHopNum": 8,
+            "internalNextHopActiveNum": 8,
+            "nexthopGroupId": 465,
+            "installedNexthopGroupId": 465,
+            "uptime": "04w0d12h",
+            "nexthops": [
+                {
+                    "flags": 5,
+                    "ip": "20.1.0.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.0.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.8.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.8.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.16.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.16.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.24.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.24.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/mock_tables/asic1/ip_route_lc_2.json
+++ b/tests/mock_tables/asic1/ip_route_lc_2.json
@@ -1,0 +1,56 @@
+{
+    "0.0.0.0/0": [
+        {
+            "prefix": "0.0.0.0/0",
+            "prefixLen": 0,
+            "protocol": "bgp",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 20,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 9,
+            "internalNextHopNum": 3,
+            "internalNextHopActiveNum": 3,
+            "nexthopGroupId": 2173,
+            "installedNexthopGroupId": 2173,
+            "uptime": "01:01:57",
+            "nexthops": [
+                {
+                    "flags": 5,
+                    "ip": "10.0.0.1",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "10.0.0.1",
+                    "afi": "ipv4",
+                    "interfaceIndex": 52,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 3,
+                    "fib": true,
+                    "ip": "10.0.0.7",
+                    "afi": "ipv4",
+                    "interfaceIndex": 29,
+                    "interfaceName": "PortChannel106",
+                    "active": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/mock_tables/asic1/ip_route_remote_lc.json
+++ b/tests/mock_tables/asic1/ip_route_remote_lc.json
@@ -1,0 +1,106 @@
+{
+    "0.0.0.0/0": [
+        {
+            "prefix": "0.0.0.0/0",
+            "prefixLen": 0,
+            "protocol": "bgp",
+            "vrfId": 0,
+            "vrfName": "default",
+            "selected": true,
+            "destSelected": true,
+            "distance": 200,
+            "metric": 0,
+            "installed": true,
+            "table": 254,
+            "internalStatus": 16,
+            "internalFlags": 13,
+            "internalNextHopNum": 8,
+            "internalNextHopActiveNum": 8,
+            "nexthopGroupId": 465,
+            "installedNexthopGroupId": 465,
+            "uptime": "04w0d12h",
+            "nexthops": [
+                {
+                    "flags": 5,
+                    "ip": "20.1.0.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.0.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.8.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.8.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.16.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.16.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 5,
+                    "ip": "20.1.24.128",
+                    "afi": "ipv4",
+                    "active": true,
+                    "recursive": true,
+                    "weight": 1
+                },
+                {
+                    "flags": 11,
+                    "fib": true,
+                    "ip": "20.1.24.128",
+                    "afi": "ipv4",
+                    "interfaceIndex": 26,
+                    "interfaceName": "Ethernet-IB1",
+                    "resolver": true,
+                    "active": true,
+                    "onLink": true,
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}

--- a/tests/show_ip_route_common.py
+++ b/tests/show_ip_route_common.py
@@ -875,3 +875,60 @@ ibgp                 6409                 6409
 Totals               6467                 6466
 
 """
+
+SHOW_IP_ROUTE_REMOTE_LC = """\
+Codes: K - kernel route, C - connected, S - static, R - RIP,
+       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
+       F - PBR, f - OpenFabric,
+       > - selected route, * - FIB route, q - queued route, r - rejected route
+
+B> 0.0.0.0/0 [200/0]   via 20.1.24.128, recursive via iBGP 04w0d12h
+                       via 20.1.16.128, recursive via iBGP 04w0d12h
+                       via 20.1.8.128, recursive via iBGP 04w0d12h
+                       via 20.1.0.128, recursive via iBGP 04w0d12h
+"""
+
+SHOW_IP_ROUTE_LC = """\
+Codes: K - kernel route, C - connected, S - static, R - RIP,
+       O - OSPF, I - IS-IS, B - BGP, E - EIGRP, N - NHRP,
+       T - Table, v - VNC, V - VNC-Direct, A - Babel, D - SHARP,
+       F - PBR, f - OpenFabric,
+       > - selected route, * - FIB route, q - queued route, r - rejected route
+
+B>*0.0.0.0/0 [20/0] via 20.1.24.128, PortChannel13, 04w0d11h
+  *                 via 20.1.16.128, PortChannel9, 04w0d11h
+  *                 via 20.1.8.128, PortChannel5, 04w0d11h
+  *                 via 20.1.0.128, PortChannel1, 04w0d11h
+"""
+
+SHOW_IP_ROUTE_REMOTE_LC_DEFAULT_ROUTE = """\
+Routing entry for 0.0.0.0/0
+  Known via "bgp", distance 200, metric 0, best
+  Last update 04w0d12h ago
+    * 20.1.24.128 recursive via iBGP
+    * 20.1.16.128 recursive via iBGP
+    * 20.1.8.128 recursive via iBGP
+    * 20.1.0.128 recursive via iBGP
+
+"""
+
+SHOW_IP_ROUTE_LC_DEFAULT_ROUTE = """\
+Routing entry for 0.0.0.0/0
+  Known via "bgp", distance 20, metric 0, best
+  Last update 04w0d11h ago
+  * 20.1.24.128, via PortChannel13
+  * 20.1.16.128, via PortChannel9
+  * 20.1.8.128, via PortChannel5
+  * 20.1.0.128, via PortChannel1
+
+"""
+
+SHOW_IP_ROUTE_LC_DEFAULT_ROUTE_2 = """\
+Routing entry for 0.0.0.0/0
+  Known via "bgp", distance 20, metric 0, best
+  Last update 01:01:51 ago
+  * 10.0.0.7, via PortChannel106
+  * 10.0.0.1, via PortChannel102
+
+"""


### PR DESCRIPTION
This is a cherry-pick PR for https://github.com/sonic-net/sonic-utilities/pull/3537

* update show ip route for voq chassis

* add UT

* add more UT

* Fix linter errors

* fix UT

* make linter happy

---------

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

