### PR TITLE
[manual] [PR:3926] feat: support specific BP port info for show int (#3926)

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -112,6 +112,8 @@ def description(interfacename, namespace, display, verbose):
         interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
 
         cmd += ['-i', str(interfacename)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-d', str(display)]
     else:
         cmd += ['-d', str(display)]
 
@@ -143,6 +145,9 @@ def status(interfacename, namespace, display, verbose):
         interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
 
         cmd += ['-i', str(interfacename)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-d', str(display)]
+
     else:
         cmd += ['-d', str(display)]
 
@@ -166,6 +171,8 @@ def tpid(interfacename, namespace, display, verbose):
         interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
 
         cmd += ['-i', str(interfacename)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-d', str(display)]
     else:
         cmd += ['-d', str(display)]
 
@@ -607,6 +614,8 @@ def counters(ctx, verbose, period, interface, printall, namespace, display):
         if interface is not None:
             interface = try_convert_interfacename_from_alias(ctx, interface)
             cmd += ['-i', str(interface)]
+            if multi_asic.is_multi_asic():
+                cmd += ['-s', str(display)]
         else:
             cmd += ['-s', str(display)]
         if namespace is not None:
@@ -794,6 +803,8 @@ def autoneg_status(interfacename, namespace, display, verbose):
         interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
 
         cmd += ['-i', str(interfacename)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-d', str(display)]
     else:
         cmd += ['-d', str(display)]
 
@@ -829,6 +840,8 @@ def link_training_status(interfacename, namespace, display, verbose):
         interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
 
         cmd += ['-i', str(interfacename)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-d', str(display)]
     else:
         cmd += ['-d', str(display)]
 
@@ -862,6 +875,8 @@ def fec_status(interfacename, namespace, display, verbose):
         interfacename = try_convert_interfacename_from_alias(ctx, interfacename)
 
         cmd += ['-i', str(interfacename)]
+        if multi_asic.is_multi_asic():
+            cmd += ['-d', str(display)]
     else:
         cmd += ['-d', str(display)]
 

--- a/tests/multi_asic_intfutil_test.py
+++ b/tests/multi_asic_intfutil_test.py
@@ -49,6 +49,13 @@ intf_status_asic0_all = """\
 PortChannel1002           N/A      80G   9100    N/A           N/A            trunk      up       up              N/A         N/A
 PortChannel4001           N/A      80G   9100    N/A           N/A           routed      up       up              N/A         N/A
 """
+
+intf_status_asic0_bp0 = """\
+   Interface        Lanes    Speed    MTU    FEC         Alias             Vlan    Oper    Admin    Type    Asym PFC
+------------  -----------  -------  -----  -----  ------------  ---------------  ------  -------  ------  ----------
+Ethernet-BP0  93,94,95,96      40G   9100    N/A  Ethernet-BP0  PortChannel4001      up       up     N/A         off
+"""
+
 intf_description = """\
   Interface    Oper    Admin        Alias               Description
 -----------  ------  -------  -----------  ------------------------
@@ -66,6 +73,12 @@ intf_description_all = """\
   Ethernet-BP4      up       up    Ethernet-BP4          ASIC1:Eth1-ASIC1
 Ethernet-BP256      up       up  Ethernet-BP256         ASIC0:Eth16-ASIC0
 Ethernet-BP260      up       up  Ethernet-BP260         ASIC0:Eth17-ASIC0
+"""
+
+intf_description_bp0 = """\
+   Interface    Oper    Admin         Alias       Description
+------------  ------  -------  ------------  ----------------
+Ethernet-BP0      up       up  Ethernet-BP0  ASIC1:Eth0-ASIC1
 """
 
 intf_description_asic0 = """\
@@ -118,6 +131,16 @@ class TestInterfacesMultiAsic(object):
         assert return_code == 0
         assert result == intf_status_asic0_all
 
+    def test_multi_asic_interface_status_bp0(self):
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'status', '-i', 'Ethernet-BP0', '-d', 'all']
+        )
+
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == intf_status_asic0_bp0
+
     def test_multi_asic_interface_status_asic0(self):
         return_code, result = get_result_and_return_code(['intfutil', '-c', 'status', '-n', 'asic0'])
         print("return_code: {}".format(return_code))
@@ -139,6 +162,16 @@ class TestInterfacesMultiAsic(object):
         assert return_code == 0
         assert result == intf_description_all
 
+    def test_multi_asic_interface_desc_bp0(self):
+        return_code, result = get_result_and_return_code(
+            ['intfutil', '-c', 'description', '-i', 'Ethernet-BP0', '-d', 'all']
+        )
+
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == intf_description_bp0
+
     def test_multi_asic_interface_asic0(self):
         return_code, result = get_result_and_return_code(['intfutil', '-c', 'description', '-n', 'asic0'])
         print("return_code: {}".format(return_code))
@@ -153,7 +186,7 @@ class TestInterfacesMultiAsic(object):
         assert return_code == 0
         assert result == intf_description_asic0_all
 
-    def test_invalid_asic_name(self):
+    def test_invalid_asic_name_all(self):
         return_code, result = get_result_and_return_code(['intfutil', '-c', 'description', '-n', 'asic99', '-d', 'all'])
         print("return_code: {}".format(return_code))
         print("result = {}".format(result))

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -161,6 +161,16 @@ Ethernet-BP4        U        8  0.00 B/s    0.00/s      0.00%         0     1,00
 Reminder: Please execute 'show interface counters -d all' to include internal links
 
 """
+
+multi_asic_intf_counters_bp0 = """\
+       IFACE    STATE    RX_OK    RX_BPS    RX_PPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK    TX_BPS    TX_PPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
+------------  -------  -------  --------  --------  ---------  --------  --------  --------  -------  --------  --------  ---------  --------  --------  --------
+Ethernet-BP0        U        6  0.00 B/s    0.00/s      0.00%         0     1,000       N/A       60  0.00 B/s    0.00/s      0.00%       N/A       N/A       N/A
+
+Reminder: Please execute 'show interface counters -d all' to include internal links
+
+"""  # noqa: E501
+
 multi_asic_intf_counters_period = """\
 The rates are calculated within 3 seconds period
     IFACE    STATE    RX_OK    RX_BPS    RX_UTIL    RX_ERR    RX_DRP    RX_OVR    TX_OK    TX_BPS    TX_UTIL    TX_ERR    TX_DRP    TX_OVR
@@ -679,6 +689,14 @@ class TestMultiAsicPortStat(object):
         print("result = {}".format(result))
         assert return_code == 0
         assert result == multi_asic_intf_counters_asic0_printall
+
+    def test_multi_show_intf_counters_bp0(self):
+        return_code, result = get_result_and_return_code(
+            ['portstat', '-a', '-i', 'Ethernet-BP0', '-s', 'all'])
+        print("return_code: {}".format(return_code))
+        print("result = {}".format(result))
+        assert return_code == 0
+        assert result == multi_asic_intf_counters_bp0
 
     def test_multi_show_intf_counters_period(self):
         return_code, result = get_result_and_return_code(

--- a/tests/show_test.py
+++ b/tests/show_test.py
@@ -396,6 +396,24 @@ class TestShowInterfaces(object):
         mock_run_command.assert_called_once_with(['intfutil', '-c', 'description', '-i', 'Ethernet0', '-n', 'asic0'], display_cmd=True)
 
     @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_description(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['description'],
+            ['Ethernet-BP0', '-d', 'all', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['intfutil', '-c', 'description', '-i', 'Ethernet-BP0', '-d', 'all'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
     @patch.object(click.Choice, 'convert', MagicMock(return_value='asic0'))
     def test_status(self, mock_run_command):
         runner = CliRunner()
@@ -406,6 +424,24 @@ class TestShowInterfaces(object):
         mock_run_command.assert_called_once_with(['intfutil', '-c', 'status', '-i', 'Ethernet0', '-n', 'asic0'], display_cmd=True)
 
     @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_status(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['status'],
+            ['Ethernet-BP0', '-d', 'all', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['intfutil', '-c', 'status', '-i', 'Ethernet-BP0', '-d', 'all'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
     @patch.object(click.Choice, 'convert', MagicMock(return_value='asic0'))
     def test_tpid(self, mock_run_command):
         runner = CliRunner()
@@ -414,6 +450,24 @@ class TestShowInterfaces(object):
         print(result.output)
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['intfutil', '-c', 'tpid', '-i', 'Ethernet0', '-n', 'asic0'], display_cmd=True)
+
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_tpid(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['tpid'],
+            ['Ethernet-BP0', '-d', 'all', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['intfutil', '-c', 'tpid', '-i', 'Ethernet-BP0', '-d', 'all'],
+            display_cmd=True,
+        )
 
     @patch('utilities_common.cli.run_command')
     def test_transceiver_lpmode(self, mock_run_command):
@@ -443,6 +497,24 @@ class TestShowInterfaces(object):
         print(result.output)
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['portstat', '-a', '-p', '3', '-i', 'Ethernet0', '-n', 'asic0'], display_cmd=True)
+
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_counters(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['counters'],
+            ['-i', 'Ethernet-BP0', '-p', '3', '-a', '-d', 'all', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['portstat', '-a', '-p', '3', '-i', 'Ethernet-BP0', '-s', 'all'],
+            display_cmd=True,
+        )
 
     @patch('utilities_common.cli.run_command')
     def test_counters_error(self, mock_run_command):
@@ -482,6 +554,24 @@ class TestShowInterfaces(object):
         mock_run_command.assert_called_once_with(['intfutil', '-c', 'autoneg', '-i', 'Ethernet0', '-n', 'asic0'], display_cmd=True)
 
     @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_autoneg_status(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['autoneg'].commands['status'],
+            ['Ethernet-BP0', '-d', 'all', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['intfutil', '-c', 'autoneg', '-i', 'Ethernet-BP0', '-d', 'all'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
     @patch.object(click.Choice, 'convert', MagicMock(return_value='asic0'))
     def test_link_training_status(self, mock_run_command):
         runner = CliRunner()
@@ -490,6 +580,59 @@ class TestShowInterfaces(object):
         print(result.output)
         assert result.exit_code == 0
         mock_run_command.assert_called_once_with(['intfutil', '-c', 'link_training', '-i', 'Ethernet0', '-n', 'asic0'], display_cmd=True)
+
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_link_training_status(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['link-training'].commands['status'],
+            ['Ethernet-BP0', '-d', 'all', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['intfutil', '-c', 'link_training', '-i', 'Ethernet-BP0', '-d', 'all'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='asic0'))
+    def test_fec_status(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['fec'].commands['status'],
+            ['Ethernet0', '-n', 'asic0', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['intfutil', '-c', 'fec', '-i', 'Ethernet0', '-n', 'asic0'],
+            display_cmd=True,
+        )
+
+    @patch('utilities_common.cli.run_command')
+    @patch.object(click.Choice, 'convert', MagicMock(return_value='all'))
+    @patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=True))
+    def test_bp_port_fec_status(self, mock_run_command):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands['interfaces'].commands['fec'].commands['status'],
+            ['Ethernet-BP0', '-d', 'all', '--verbose'],
+        )
+
+        print(result.exit_code)
+        print(result.output)
+        assert result.exit_code == 0
+        mock_run_command.assert_called_once_with(
+            ['intfutil', '-c', 'fec', '-i', 'Ethernet-BP0', '-d', 'all'],
+            display_cmd=True,
+        )
 
     def teardown(self):
         print('TEAR DOWN')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
This PR resolves https://github.com/sonic-net/sonic-utilities/issues/3925. 

In this PR, I enhanced the `show interfaces` command to support specific BP port information display for multi-ASIC devices, for example, T2 Chassis. It means we can use commands like `show interfaces status Ethernet-BP128 -d all` to get the status of a backplane interface, e.g. Ethernet-BP128 itself, after this PR, just like what we used to do for a specific frontend interface (plus an extra `-d all` of course).

The commands I updated for getting specific BP interface information:

- `show interfaces description`
- `show interfaces status`
- `show interfaces tpid`
- `show interfaces counters`
- `show interfaces autoneg status`
- `show interfaces link-training status`
- `show interfaces fec status`

Please note that nothing has changed when running these commands on a single-ASIC device, and nothing has changed when running these commands on a multi-ASIC device without specifying an interface. The only behavior change is when we run the above commands for a specific interface on a multi-ASIC device.

#### How I did it

#### How to verify it

We can try the following commands after this PR to see the information of the backplane interface Ethernet-BP128 itself:

- `show interfaces description Ethernet-BP128 -d all`
- `show interfaces status Ethernet-BP128 -d all`
- `show interfaces tpid Ethernet-BP128 -d all`
- `show interfaces counters -i Ethernet-BP128 -d all`
- `show interfaces autoneg status Ethernet-BP128 -d all`
- `show interfaces link-training status Ethernet-BP128 -d all`
- `show interfaces fec status Ethernet-BP128 -d all`

#### Previous command output (if the output of a command-line utility has changed)

Before this PR, when we run `show interfaces status Ethernet-BP128 -d all`, the output will be empty:

```
admin@dut:~$ show int status Ethernet-BP128 -d all
     Interface                Lanes    Speed    MTU    FEC         Alias           Vlan    Oper    Admin    Type    Asym PFC
--------------  -------------------  -------  -----  -----  ------------  -------------  ------  -------  ------  ----------
```

#### New command output (if the output of a command-line utility has changed)

After this PR, when we run `show interfaces status Ethernet-BP128 -d all`, the output will be something like the following:

```
admin@dut:~$ show int status Ethernet-BP128 -d all
     Interface                Lanes    Speed    MTU    FEC         Alias           Vlan    Oper    Admin    Type    Asym PFC
--------------  -------------------  -------  -----  -----  ------------  -------------  ------  -------  ------  ----------
Ethernet-BP128  1700,1701,1702,1703     100G   9000    N/A  Eth310-ASIC1  PortChannel38      up       up     N/A         off
```
