### PR TITLE
[202412][GCU] Update BUFFER_PROFILE field operation validator

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -165,10 +165,6 @@ def rdma_config_update_validator(patch_element):
     return rdma_config_update_validator_common(patch_element, exact_field_match=True, remove_port=True)
 
 
-def buffer_profile_config_update_validator(patch_element):
-    return rdma_config_update_validator_common(patch_element)
-
-
 def wred_profile_config_update_validator(patch_element):
     return rdma_config_update_validator_common(patch_element)
 

--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -104,9 +104,7 @@
             }
         },
         "BUFFER_PROFILE": {
-            "field_operation_validators": [
-                "generic_config_updater.field_operation_validators.buffer_profile_config_update_validator"
-            ],
+            "field_operation_validators": [ "generic_config_updater.field_operation_validators.rdma_config_update_validator" ],
             "validator_data": {
                 "rdma_config_update_validator": {
                     "Dynamic threshold tuning": {

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -1,15 +1,18 @@
-import pytest
+import io
 import unittest
 import mock
+import json
+import subprocess
 import generic_config_updater
 import generic_config_updater.field_operation_validators as fov
 import generic_config_updater.gu_common as gu_common
 
-from unittest.mock import mock_open
+from unittest.mock import MagicMock, Mock, mock_open
 from mock import patch
+from sonic_py_common.device_info import get_hwsku, get_sonic_version_info
 
 
-class TestValidateFieldOperation:
+class TestValidateFieldOperation(unittest.TestCase):
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
     def test_port_config_update_validator_valid_speed_no_state_db(self):
@@ -102,40 +105,6 @@ class TestValidateFieldOperation:
     def test_rdma_config_update_validator_td3_asic_invalid_version(self):
         patch_element = {"path": "/BUFFER_POOL/ingress_lossless_pool/xoff", "op": "replace", "value": "234234"}
         assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
-
-    @pytest.mark.parametrize(
-        "field,value,op", [
-            pytest.param("xoff", "1000", "replace"),
-            pytest.param("dynamic_th", "0", "replace"),
-            pytest.param("packet_discard_action", "trim", "add"),
-            pytest.param("packet_discard_action", "drop", "replace")
-        ]
-    )
-    @pytest.mark.parametrize(
-        "asic", [
-            "spc4",
-            "spc5",
-            "th5"
-        ]
-    )
-    def test_buffer_profile_config_update_validator(self, asic, field, value, op):
-        patch_element = {
-            "path": "/BUFFER_PROFILE/sample_profile/{}".format(field),
-            "op": op,
-            "value": value
-        }
-
-        with (
-            patch(
-                "generic_config_updater.field_operation_validators.get_asic_name",
-                return_value=asic
-            ),
-            patch(
-                "sonic_py_common.device_info.get_sonic_version_info",
-                return_value={"build_version": "SONiC.20241200"}
-            )
-        ):
-            assert fov.buffer_profile_config_update_validator(patch_element) is True
 
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
@@ -262,7 +231,7 @@ class TestValidateFieldOperation:
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
         target_config = {"PFC_WD": {"GLOBAL": {}}}
         config_wrapper = gu_common.ConfigWrapper()
-        pytest.raises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
+        self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
 
     def test_validate_field_operation_legal__rm_loopback1(self):
         old_config = {
@@ -298,7 +267,7 @@ class TestValidateFieldOperation:
             }
         }
         config_wrapper = gu_common.ConfigWrapper()
-        pytest.raises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
+        self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
 
     def test_validate_field_operation_illegal__dataacl_table_type_update_and_rule_change(self):
         old_config = {
@@ -326,8 +295,8 @@ class TestValidateFieldOperation:
             }
         }
         config_wrapper = gu_common.ConfigWrapper()
-        pytest.raises(gu_common.IllegalPatchOperationError,
-                      config_wrapper.validate_field_operation, old_config, target_config)
+        self.assertRaises(gu_common.IllegalPatchOperationError,
+                          config_wrapper.validate_field_operation, old_config, target_config)
 
     def test_validate_field_operation_legal__only_dataacl_table_type_update(self):
         old_config = {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

UPDATE: Closed PR.

#244 triggered a regression since it swapped out the existing validator name for a new one that has nothing configured on it. This PR brings the existing BUFFER_PROFILE validator back.

Error:
```
admin@STR-SN5640-RDMA-1:~$ sudo config apply-patch -v drop.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "replace", "path": "/BUFFER_PROFILE/queue1_downlink_lossy_profile/packet_discard_action", "value": "trim"}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Failed to apply patch due to: Failed to apply patch on the following scopes:
- localhost: module 'generic_config_updater.field_operation_validators' has no attribute 'buffer_profile_config_update_validator'
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Failed to apply patch on the following scopes:
- localhost: module 'generic_config_updater.field_operation_validators' has no attribute 'buffer_profile_config_update_validator'
```

#### How I did it
Swap validator values
#### How to verify it
```
# Switch to trim
admin@STR-SN5640-RDMA-1:~$ cat drop.json 
[{"op":"replace","path":"/BUFFER_PROFILE/queue1_downlink_lossy_profile/packet_discard_action","value":"trim"}]
admin@STR-SN5640-RDMA-1:~$ sudo config apply-patch -v drop.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "replace", "path": "/BUFFER_PROFILE/queue1_downlink_lossy_profile/packet_discard_action", "value": "trim"}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Sorter - Strict: Validating patch is not making changes to tables without YANG models.
Patch Sorter - Strict: Validating target config according to YANG models.
Patch Sorter - Strict: Sorting patch updates.
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier: localhost: applying 1 change in order:
Patch Applier:   * [{"op": "replace", "path": "/BUFFER_PROFILE/queue1_downlink_lossy_profile/packet_discard_action", "value": "trim"}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
admin@STR-SN5640-RDMA-1:~$ sudo tail -n 10 /var/log/swss/sairedis.rec | grep PROFILE_PACKET_ADMISSION
2025-10-09.01:59:14.535552|s|SAI_OBJECT_TYPE_BUFFER_PROFILE:oid:0x19000000005472|SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION=SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP_AND_TRIM
2025-10-09.01:59:15.734450|s|SAI_OBJECT_TYPE_BUFFER_PROFILE:oid:0x19000000005472|SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION=SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP_AND_TRIM

# Switch to drop now
admin@STR-SN5640-RDMA-1:~$ cat drop.json 
[{"op":"replace","path":"/BUFFER_PROFILE/queue1_downlink_lossy_profile/packet_discard_action","value":"drop"}]
admin@STR-SN5640-RDMA-1:~$ sudo config apply-patch -v drop.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "replace", "path": "/BUFFER_PROFILE/queue1_downlink_lossy_profile/packet_discard_action", "value": "drop"}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Sorter - Strict: Validating patch is not making changes to tables without YANG models.
Patch Sorter - Strict: Validating target config according to YANG models.
Patch Sorter - Strict: Sorting patch updates.
Patch Applier: The localhost patch was converted into 1 change:
Patch Applier: localhost: applying 1 change in order:
Patch Applier:   * [{"op": "replace", "path": "/BUFFER_PROFILE/queue1_downlink_lossy_profile/packet_discard_action", "value": "drop"}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.
Patch applied successfully.
admin@STR-SN5640-RDMA-1:~$ sudo tail -n 10 /var/log/swss/sairedis.rec | grep PROFILE_PACKET_ADMISSION
2025-10-09.02:03:00.650768|s|SAI_OBJECT_TYPE_BUFFER_PROFILE:oid:0x19000000005472|SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION=SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP
2025-10-09.02:03:00.866941|s|SAI_OBJECT_TYPE_BUFFER_PROFILE:oid:0x19000000005472|SAI_BUFFER_PROFILE_ATTR_PACKET_ADMISSION_FAIL_ACTION=SAI_BUFFER_PROFILE_PACKET_ADMISSION_FAIL_ACTION_DROP
```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

