### PR TITLE
[202412] Added MAX pre-fec_ber for FEC counter (#4027)

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -5147,11 +5147,11 @@ The "fec-stats" subcommand is used to disply the interface fec related statistic
 - Example:
   ```
   admin@ctd615:~$ show interfaces counters fec-stats
-        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER
-  -----------  -------  ----------  ------------  ----------------  -------------  --------------
-   Ethernet0        U           0             0                 0    1.48e-20       0.00e+00
-   Ethernet8        U           0             0                 0    1.98e-19       0.00e+00
-  Ethernet16        U           0             0                 0    1.77e-20       0.00e+00
+        IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX
+  -----------  -------  ----------  ------------  ----------------  -------------  --------------    ---------------
+   Ethernet0        U           0             0                 0        1.48e-20        0.00e+00           1.78e-16
+   Ethernet8        U           0             0                 0        1.98e-19        0.00e+00           1.67e-14
+  Ethernet16        U           0             0                 0        1.77e-20        0.00e+00           1.37e-13
   ```
 
 The "trim" subcommand is used to display the interface packet trimming related statistic.

--- a/tests/portstat_test.py
+++ b/tests/portstat_test.py
@@ -42,11 +42,11 @@ Ethernet8      N/A        6  1350.00 KB/s    9000.00/s        N/A       100     
 """  # noqa: E501
 
 intf_fec_counters = """\
-    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER
----------  -------  ----------  ------------  ----------------  -------------  --------------
-Ethernet0        D     130,402             3                 4            N/A             N/A
-Ethernet4      N/A     110,412             1                 0            N/A             N/A
-Ethernet8      N/A     100,317             0                 0            N/A             N/A
+    IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX
+---------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------
+Ethernet0        D     130,402             3                 4            N/A             N/A                N/A
+Ethernet4      N/A     110,412             1                 0            N/A             N/A                N/A
+Ethernet8      N/A     100,317             0                 0            N/A             N/A                N/A
 """
 
 intf_fec_counters_fec_hist = """\

--- a/utilities_common/portstat.py
+++ b/utilities_common/portstat.py
@@ -35,12 +35,15 @@ header_all = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'RX_ERR'
 header_std = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_UTIL', 'RX_ERR', 'RX_DRP', 'RX_OVR',
               'TX_OK', 'TX_BPS', 'TX_UTIL', 'TX_ERR', 'TX_DRP', 'TX_OVR']
 header_errors_only = ['IFACE', 'STATE', 'RX_ERR', 'RX_DRP', 'RX_OVR', 'TX_ERR', 'TX_DRP', 'TX_OVR']
-header_fec_only = ['IFACE', 'STATE', 'FEC_CORR', 'FEC_UNCORR', 'FEC_SYMBOL_ERR', 'FEC_PRE_BER', 'FEC_POST_BER']
+header_fec_only = ['IFACE', 'STATE', 'FEC_CORR', 'FEC_UNCORR', 'FEC_SYMBOL_ERR', 'FEC_PRE_BER',
+                   'FEC_POST_BER', 'FEC_PRE_BER_MAX']
 header_rates_only = ['IFACE', 'STATE', 'RX_OK', 'RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_OK', 'TX_BPS', 'TX_PPS', 'TX_UTIL']
 header_trim_only = ['IFACE', 'STATE', 'TRIM_PKTS', 'TRIM_TX_PKTS', 'TRIM_DRP_PKTS']
 
-rates_key_list = ['RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_BPS', 'TX_PPS', 'TX_UTIL', 'FEC_PRE_BER', 'FEC_POST_BER']
-ratestat_fields = ("rx_bps",  "rx_pps", "rx_util", "tx_bps", "tx_pps", "tx_util", "fec_pre_ber", "fec_post_ber")
+rates_key_list = ['RX_BPS', 'RX_PPS', 'RX_UTIL', 'TX_BPS', 'TX_PPS', 'TX_UTIL', 'FEC_PRE_BER',
+                  'FEC_POST_BER', 'FEC_PRE_BER_MAX']
+ratestat_fields = ("rx_bps",  "rx_pps", "rx_util", "tx_bps", "tx_pps", "tx_util", "fec_pre_ber", "fec_post_ber",
+                   "fec_pre_ber_max")
 RateStats = namedtuple("RateStats", ratestat_fields)
 
 """
@@ -213,11 +216,12 @@ class Portstat(object):
             tx_ovr = self.db.get(self.db.CHASSIS_STATE_DB, key, "tx_ovr")
             fec_pre_ber = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_pre_ber")
             fec_post_ber = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_post_ber")
+            fec_pre_ber_max = self.db.get(self.db.CHASSIS_STATE_DB, key, "fec_pre_ber_max")
             port_alias = key.split("|")[-1]
             cnstat_dict[port_alias] = NStats._make([rx_ok, rx_err, rx_drop, rx_ovr, tx_ok, tx_err, tx_drop, tx_ovr] +
                                                    [STATUS_NA] * (len(NStats._fields) - 8))._asdict()
             ratestat_dict[port_alias] = RateStats._make([rx_bps, rx_pps, rx_util, tx_bps,
-                                                        tx_pps, tx_util, fec_pre_ber, fec_post_ber])
+                                                        tx_pps, tx_util, fec_pre_ber, fec_post_ber, fec_pre_ber_max])
         self.cnstat_dict.update(cnstat_dict)
         self.ratestat_dict.update(ratestat_dict)
 
@@ -298,7 +302,7 @@ class Portstat(object):
             """
                 Get the rates from specific table.
             """
-            fields = ["0", "0", "0", "0", "0", "0", "0", "0"]
+            fields = ["0", "0", "0", "0", "0", "0", "0", "0", "0"]
             for pos, name in enumerate(rates_key_list):
                 full_table_id = RATES_TABLE_PREFIX + table_id
                 counter_data = self.db.get(self.db.COUNTERS_DB, full_table_id, name)
@@ -428,7 +432,8 @@ class Portstat(object):
                               format_number_with_comma(data['fec_uncorr']),
                               format_number_with_comma(data['fec_symbol_err']),
                               format_fec_ber(rates.fec_pre_ber),
-                              format_fec_ber(rates.fec_post_ber)))
+                              format_fec_ber(rates.fec_post_ber),
+                              format_fec_ber(rates.fec_pre_ber_max)))
             elif rates_only:
                 header = header_rates_only
                 table.append((key, self.get_port_state(key),


### PR DESCRIPTION
202412 cherry-pick for https://github.com/sonic-net/sonic-utilities/pull/4027

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added new column FEC_PRE_BER_MAX in portstat -f

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show interfaces counters fec-stats 
      IFACE    STATE        FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER
-----------  -------  --------------  ------------  ----------------  -------------  --------------
  Ethernet0        U      14,891,931            36        14,892,752       7.53e-11               0
  Ethernet1        U      11,001,725            32        11,002,421       0                      0
  Ethernet2        U       2,508,567            32         2,509,115       0                      0
  Ethernet3        U      10,489,724            32        10,500,020       5.65e-11               0
  Ethernet4        U       1,478,440            32         1,478,993       9.41e-12               0
```

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show interfaces counters fec-stats 
      IFACE    STATE    FEC_CORR    FEC_UNCORR    FEC_SYMBOL_ERR    FEC_PRE_BER    FEC_POST_BER    FEC_PRE_BER_MAX
-----------  -------  ----------  ------------  ----------------  -------------  --------------  -----------------
  Ethernet0        U         143             0               143       1.88e-11               0           7.53e-11
  Ethernet1        U          98             0                98       2.82e-11               0           4.71e-11
  Ethernet2        U          34             0                34       0                      0           2.82e-11
  Ethernet3        U         195             0               195       9.41e-12               0           8.47e-11
  Ethernet4        D          20             0                20       0                      0           1.88e-11
```
