### PR TITLE
[GCU]Skip speed validation for chassis.

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -155,7 +155,10 @@ def port_config_update_validator(patch_element):
                 return False
             return True
         if field == "speed":
-            supported_speeds_str = read_statedb_entry("PORT_TABLE", port, "supported_speeds") or ''
+            # For chassis, skip speed validation as desired speed is not in supported_speeds of StateDB.
+            if device_info.is_chassis():
+                return True
+            supported_speeds_str = read_statedb_entry(scope, "PORT_TABLE", port, "supported_speeds") or ''
             try:
                 supported_speeds = [int(s) for s in supported_speeds_str.split(',') if s]
                 if supported_speeds and int(value) not in supported_speeds:

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -29,7 +29,38 @@ class TestValidateFieldOperation(unittest.TestCase):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
         assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
 
-    @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
+    @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
+    def test_port_config_update_validator_invalid_speed_for_chassis(self):
+        # 235 is in supported speeds, but for chassis, skip speed validation
+        patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": 235}}
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
+    @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=False))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
+    def test_port_config_update_validator_valid_speed_for_nonchassis(self):
+        # 234 is not in supported speeds, but for chassis, skip speed validation
+        patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": 234}}
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
+    @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=False))
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
+    def test_port_config_update_validator_invalid_speed_for_nonchassis(self):
+        # 235 is not in supported speeds, but for chassis, skip speed validation
+        patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": 235}}
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+
+    @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
+           mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "234"}
         assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Skip port speed validation for chassis

MSFT ADO: 35177627

Issue: https://github.com/sonic-net/sonic-buildimage/issues/23945

#### How I did it
If device is chassis, skip port speed validation when applied a jsonpatch contains port speed related change.

#### How to verify it

Tested in lab and stage device.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

