### PR TITLE
[GCU] Don't remove all entries in a table when just adding/modifying keys within an existing table

### DIFF
--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1075,7 +1075,8 @@ class KeyLevelMoveGenerator:
         for tokens in self._get_non_existing_keys_tokens(diff.current_config, diff.target_config):
             table = tokens[0]
             # if table has a single key, delete the whole table because empty tables are not allowed in ConfigDB
-            if len(diff.current_config[table]) == 1:
+            # BUT only if the table won't exist in target config (i.e., not adding new keys to it)
+            if len(diff.current_config[table]) == 1 and table not in diff.target_config:
                 yield JsonMove(diff, OperationType.REMOVE, [table])
             else:
                 yield JsonMove(diff, OperationType.REMOVE, tokens)
@@ -1477,6 +1478,18 @@ class UpperLevelMoveExtender:
             return
 
         upper_current_tokens = move.current_config_tokens[:-1]
+
+        # Don't extend key-level ADD/REPLACE operations to table-level when just adding/modifying keys within an existing table
+        # This prevents incorrectly replacing/removing entire tables when only adding/updating individual keys
+        # We still allow REMOVE operations to be extended to handle dependency cleanup properly
+        if len(upper_current_tokens) == 1:  # This would be a table-level operation
+            table = upper_current_tokens[0]
+            # If table exists in both current and target, don't extend ADD/REPLACE to table level
+            # The key-level operation is sufficient for additions/modifications
+            if table in diff.current_config and table in diff.target_config:
+                if move.op_type in [OperationType.ADD, OperationType.REPLACE]:
+                    return
+
         operation_type = self._get_upper_operation(upper_current_tokens, diff)
 
         upper_target_tokens = None


### PR DESCRIPTION
Signed-off-by: Anand Mehra (anamehra) <anamehra@cisco.com>


<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed an issue in config apply-patch where adding a new entry to a table (e.g., INTERFACE) incorrectly removes all existing entries in that table before adding them back, causing unnecessary disruption.

Fixes: https://github.com/sonic-net/sonic-buildimage/issues/24464 for 202405-msft

#### How I did it
Made two changes to generic_config_updater/patch_sorter.py:

1. KeyLevelMoveGenerator: Added check to prevent deleting entire table when it has a single key if that table will continue to exist in the target config. Now only deletes the whole table when table not in diff.target_config.
2. UpperLevelMoveExtender: Added logic to prevent key-level ADD/REPLACE operations from being extended to table-level operations when the table exists in both current and target configs. This keeps operations at the key level, avoiding unnecessary removal of unaffected entries.

#### How to verify it
1. Create a config with an INTERFACE table containing one entry (e.g., Ethernet0)
2. Apply a patch that adds a new entry (e.g., Ethernet10) to the INTERFACE table
3. Verify that only the new entry is added and the existing Ethernet0 entry is NOT removed during the operation
4. Check logs to confirm no REMOVE operations are generated for unaffected entries

```
root@yy39-lc2:/home/admin# config apply-patch patch.test.vz --dry-run
** DRY RUN EXECUTION **
Patch Applier: asic2: Patch application starting.
Patch Applier: asic2: Patch: [{"op": "add", "path": "/PORT/Ethernet256", "value": {"admin_status": "up", "alias": "Eth0/2/0/32", "asic_port_name": "Eth9-ASIC2", "description": "ARISTA33T1:Ethernet1", "fec": "rs", "index": "0", "lanes": "264,265,266,267", "mtu": "9100", "pfc_asym": "off", "role": "Ext", "speed": "100000", "tpid": "0x8100"}}, {"op": "add", "path": "/INTERFACE/Ethernet256", "value": {}}, {"op": "add", "path": "/INTERFACE/Ethernet256|10.0.0.192~131", "value": {}}]
Patch Applier: asic2 getting current config db.
Patch Applier: asic2: simulating the target full config after applying the patch.
Patch Applier: asic2: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: asic2: validating target config does not have empty tables,
                            since they do not show up in ConfigDb.
Patch Applier: asic2: sorting patch updates.
Patch Applier: The asic2 patch was converted into 11 changes:
Patch Applier: asic2: applying 11 changes in order:
Patch Applier:   * [{"op": "remove", "path": "/CABLE_LENGTH/AZURE/Ethernet256"}]
** DryRun: Would apply [{"op": "remove", "path": "/CABLE_LENGTH/AZURE/Ethernet256"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet256/asic_port_name", "value": "Eth9-ASIC2"}]
** DryRun: Would apply [{"op": "replace", "path": "/PORT/Ethernet256/asic_port_name", "value": "Eth9-ASIC2"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet256/description", "value": "ARISTA33T1:Ethernet1"}]
** DryRun: Would apply [{"op": "replace", "path": "/PORT/Ethernet256/description", "value": "ARISTA33T1:Ethernet1"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet256/index", "value": "0"}]
** DryRun: Would apply [{"op": "replace", "path": "/PORT/Ethernet256/index", "value": "0"}]
Patch Applier:   * [{"op": "replace", "path": "/PORT/Ethernet256/speed", "value": "100000"}]
** DryRun: Would apply [{"op": "replace", "path": "/PORT/Ethernet256/speed", "value": "100000"}]
Patch Applier:   * [{"op": "add", "path": "/PORT/Ethernet256/fec", "value": "rs"}]
** DryRun: Would apply [{"op": "add", "path": "/PORT/Ethernet256/fec", "value": "rs"}]
Patch Applier:   * [{"op": "remove", "path": "/PORT/Ethernet256"}]
** DryRun: Would apply [{"op": "remove", "path": "/PORT/Ethernet256"}]
Patch Applier:   * [{"op": "add", "path": "/PORT/Ethernet256", "value": {"admin_status": "up", "alias": "Eth0/2/0/32", "asic_port_name": "Eth9-ASIC2", "description": "ARISTA33T1:Ethernet1", "fec": "rs", "index": "0", "lanes": "264,265,266,267", "mtu": "9100", "pfc_asym": "off", "role": "Ext", "speed": "100000", "tpid": "0x8100"}}]
** DryRun: Would apply [{"op": "add", "path": "/PORT/Ethernet256", "value": {"admin_status": "up", "alias": "Eth0/2/0/32", "asic_port_name": "Eth9-ASIC2", "description": "ARISTA33T1:Ethernet1", "fec": "rs", "index": "0", "lanes": "264,265,266,267", "mtu": "9100", "pfc_asym": "off", "role": "Ext", "speed": "100000", "tpid": "0x8100"}}]
Patch Applier:   * [{"op": "add", "path": "/INTERFACE/Ethernet256", "value": {}}]
** DryRun: Would apply [{"op": "add", "path": "/INTERFACE/Ethernet256", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/INTERFACE/Ethernet256|10.0.0.192~131", "value": {}}]
** DryRun: Would apply [{"op": "add", "path": "/INTERFACE/Ethernet256|10.0.0.192~131", "value": {}}]
Patch Applier:   * [{"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet256", "value": "300m"}]
** DryRun: Would apply [{"op": "add", "path": "/CABLE_LENGTH/AZURE/Ethernet256", "value": "300m"}]
Patch Applier: asic2: verifying patch updates are reflected on ConfigDB.
Patch Applier: asic2 patch application completed.
Patch applied successfully.
root@yy39-lc2:/home/admin# cat patch.test.vz 
[
    {
        "op": "add",
        "path": "/asic2/PORT/Ethernet256",
        "value": { 
            "admin_status": "up",
            "alias": "Eth0/2/0/32",
            "asic_port_name": "Eth9-ASIC2",
            "description": "ARISTA33T1:Ethernet1",
            "fec": "rs",
            "index": "0",
            "lanes": "264,265,266,267",
            "mtu": "9100",
            "pfc_asym": "off",
            "role": "Ext",
            "speed": "100000",
            "tpid": "0x8100"
        }
    },
    {
        "op": "add",
        "path": "/asic2/INTERFACE/Ethernet256",
        "value": {}
    },
    {
        "op": "add",
        "path": "/asic2/INTERFACE/Ethernet256|10.0.0.192~131",
        "value": {}
    }
]

```
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

