### PR TITLE
Enhance Route Check to detect Failed Routes in FRR

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -350,8 +350,22 @@ def fetch_routes(cmd):
     """
     Fetch routes using the given command.
     """
-    output = subprocess.check_output(cmd, text=True)
-    return json.loads(output)
+    try:
+        output = subprocess.check_output(cmd, text=True)
+        # Strip namespace prefix if present (e.g., "asic1:\n{...}" -> "{...}")
+        # The SONiC wrapper script adds "asicN:" prefix for multi-asic
+        first_line = output.split('\n')[0].strip() if output else ''
+        if re.match(r'^asic\d+:$', first_line):
+            first_newline = output.find('\n')
+            if first_newline != -1:
+                output = output[first_newline + 1:]
+        return json.loads(output)
+    except subprocess.CalledProcessError as e:
+        print_message(syslog.LOG_ERR, "Failed to execute command {}: {}".format(cmd, e))
+        return {}
+    except json.JSONDecodeError as e:
+        print_message(syslog.LOG_ERR, "Failed to parse JSON from command {}: {}".format(cmd, e))
+        return {}
 
 
 def get_frr_routes_parallel(namespace):
@@ -375,6 +389,30 @@ def get_frr_routes_parallel(namespace):
 
     v4_routes.update(v6_routes)
     print_message(syslog.LOG_DEBUG, "FRR Routes: namespace={}, routes={}".format(namespace, v4_routes))
+    return v4_routes
+
+
+def get_frr_failed_routes_parallel(namespace):
+    """
+    Read failed routes from zebra through CLI command for IPv4 and IPv6 in parallel
+    :return combined IPv4 and IPv6 failed routes dictionary.
+    """
+    if namespace == multi_asic.DEFAULT_NAMESPACE:
+        v4_route_cmd = ['show', 'ip', 'route', 'json', 'failed']
+        v6_route_cmd = ['show', 'ipv6', 'route', 'json', 'failed']
+    else:
+        v4_route_cmd = ['show', 'ip', 'route', '-n', namespace, 'json', 'failed']
+        v6_route_cmd = ['show', 'ipv6', 'route', '-n', namespace, 'json', 'failed']
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future_v4 = executor.submit(fetch_routes, v4_route_cmd)
+        future_v6 = executor.submit(fetch_routes, v6_route_cmd)
+
+        v4_routes = future_v4.result()
+        v6_routes = future_v6.result()
+
+    v4_routes.update(v6_routes)
+    print_message(syslog.LOG_DEBUG, "FRR Failed Routes: namespace={}, routes={}".format(namespace, v4_routes))
     return v4_routes
 
 
@@ -569,13 +607,15 @@ def is_feature_bgp_enabled(namespace):
 def check_frr_pending_routes(namespace):
     """
     Check FRR routes for offload flag presence by executing "show ip route json"
-    Returns a list of routes that have no offload flag.
+    return: tuple of (missed_rt, failed_rt)
     """
 
     missed_rt = []
+    failed_rt = []
     retries = FRR_CHECK_RETRIES
     for i in range(retries):
         missed_rt = []
+        failed_rt = []
         frr_routes = get_frr_routes_parallel(namespace)
 
         for _, entries in frr_routes.items():
@@ -595,12 +635,52 @@ def check_frr_pending_routes(namespace):
                 if not entry.get('offloaded', False):
                     missed_rt.append(entry)
 
-        if not missed_rt:
+                if entry.get('failed', False):
+                    failed_rt.append(entry)
+
+        if not missed_rt and not failed_rt:
             break
 
         time.sleep(FRR_WAIT_TIME)
-    print_message(syslog.LOG_DEBUG, "FRR missed routes: {}".format(missed_rt, indent=4))
-    return missed_rt
+    print_message(syslog.LOG_DEBUG, "FRR missed routes: {}".format(json.dumps(missed_rt, indent=4)))
+    print_message(syslog.LOG_DEBUG, "FRR failed routes: {}".format(json.dumps(failed_rt, indent=4)))
+    return missed_rt, failed_rt
+
+
+def check_frr_failed_routes(namespace):
+    """
+    Check FRR for failed routes by executing "show ip route json failed"
+    Returns a list of failed routes.
+    """
+
+    failed_rt = []
+    retries = FRR_CHECK_RETRIES
+    for i in range(retries):
+        failed_rt = []
+        frr_failed_routes = get_frr_failed_routes_parallel(namespace)
+
+        for _, entries in frr_failed_routes.items():
+            for entry in entries:
+                if entry['protocol'] in ('connected', 'kernel'):
+                    continue
+
+                # TODO: Also handle VRF routes. Currently this script does not check for VRF routes so it would be incorrect for us
+                # to assume they are installed in ASIC_DB, so we don't handle them.
+                if entry['vrfName'] != 'default':
+                    continue
+
+                # skip if this bgp source prefix is not selected as best
+                if not entry.get('selected', False):
+                    continue
+
+                failed_rt.append(entry)
+
+        if not failed_rt:
+            break
+
+        time.sleep(FRR_WAIT_TIME)
+    print_message(syslog.LOG_DEBUG, "FRR failed routes: {}".format(json.dumps(failed_rt, indent=4)))
+    return failed_rt
 
 
 def mitigate_installed_not_offloaded_frr_routes(namespace, missed_frr_rt, rt_appl):
@@ -733,6 +813,7 @@ def check_routes_for_namespace(namespace):
     rt_appl_miss = []
     rt_asic_miss = []
     rt_frr_miss = []
+    rt_frr_failed = []
 
     selector, subs, rt_asic = get_asicdb_routes(namespace)
 
@@ -783,17 +864,22 @@ def check_routes_for_namespace(namespace):
         results["Unaccounted_ROUTE_ENTRY_TABLE_entries"] = rt_asic_miss
 
     if is_bgp_suppress_fib_pending_enabled(namespace):
-        rt_frr_miss = check_frr_pending_routes(namespace)
+        rt_frr_miss, rt_frr_failed = check_frr_pending_routes(namespace)
+    else:
+        rt_frr_failed = check_frr_failed_routes(namespace)
 
-        if rt_frr_miss:
-            results["missed_FRR_routes"] = rt_frr_miss
+    if rt_frr_miss:
+        results["missed_FRR_routes"] = rt_frr_miss
+    if rt_frr_failed:
+        print_message(syslog.LOG_ERR, "Found {} failed routes in FRR{}".format(len(rt_frr_failed), namespace))
+        results["failed_FRR_routes"] = rt_frr_failed
 
-        if results:
-            if rt_frr_miss and not rt_appl_miss and not rt_asic_miss:
-                print_message(syslog.LOG_ERR, "Some routes are not set offloaded in FRR{} but all "
-                              "routes in APPL_DB and ASIC_DB are in sync".format(namespace))
-                if is_suppress_fib_pending_enabled(namespace):
-                    mitigate_installed_not_offloaded_frr_routes(namespace, rt_frr_miss, rt_appl)
+    if results:
+        if rt_frr_miss and not rt_appl_miss and not rt_asic_miss:
+            print_message(syslog.LOG_ERR, "Some routes are not set offloaded in FRR{} but all "
+                            "routes in APPL_DB and ASIC_DB are in sync".format(namespace))
+            if is_suppress_fib_pending_enabled(namespace):
+                mitigate_installed_not_offloaded_frr_routes(namespace, rt_frr_miss, rt_appl)
 
     return results, adds, deletes
 

--- a/tests/route_check_test.py
+++ b/tests/route_check_test.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from tests.route_check_test_data import (
     APPL_DB, MULTI_ASIC, NAMESPACE, DEFAULTNS, ARGS, ASIC_DB, CONFIG_DB,
     DEFAULT_CONFIG_DB, APPL_STATE_DB, DESCR, OP_DEL, OP_SET, PRE, RESULT, RET, TEST_DATA,
-    UPD, FRR_ROUTES
+    UPD, FRR_ROUTES, FRR_FAILED_ROUTES
 )
 
 import pytest
@@ -252,8 +252,13 @@ class TestRouteCheck(object):
 
     def mock_check_output(self, ct_data, *args, **kwargs):
         ns = self.extract_namespace_from_args(args[0])
-        if 'show runningconfiguration bgp' in ' '.join(args[0]):
+        cmd_str = ' '.join(args[0])
+        if 'show runningconfiguration bgp' in cmd_str:
             return 'bgp suppress-fib-pending'
+        elif 'failed' in cmd_str:
+            # Return failed routes for 'show ip route json failed' command
+            routes = ct_data.get(FRR_FAILED_ROUTES, {}).get(ns, {})
+            return json.dumps(routes)
         else:
             routes = ct_data.get(FRR_ROUTES, {}).get(ns, {})
             return json.dumps(routes)

--- a/tests/route_check_test_data.py
+++ b/tests/route_check_test_data.py
@@ -10,6 +10,7 @@ APPL_STATE_DB = 14
 PRE = "pre-value"
 UPD = "update"
 FRR_ROUTES = "frr-routes"
+FRR_FAILED_ROUTES = "frr-failed-routes"
 RESULT = "res"
 DEFAULTNS=""
 ASIC0 = "asic0"
@@ -969,6 +970,334 @@ TEST_DATA = {
                     },
                 ],
             },
+        },
+    },
+    "24": {
+        DESCR: "single-asic with failed FRR routes",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        RET: -1,
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_FAILED_ROUTES: {
+            DEFAULTNS: {
+                "10.10.196.100/31": [
+                    {
+                        "prefix": "10.10.196.100/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "failed": True,
+                    },
+                ],
+            }
+        },
+        RESULT: {
+            DEFAULTNS: {
+                "failed_FRR_routes": [
+                    {
+                        "prefix": "10.10.196.100/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "failed": True,
+                    },
+                ]
+            }
+        }
+    },
+    "25": {
+        DESCR: "multi-asic with failed FRR routes on one asic",
+        MULTI_ASIC: True,
+        NAMESPACE: ['asic0', 'asic1'],
+        ARGS: "route_check -m INFO -i 1000",
+        RET: -1,
+        PRE: {
+            ASIC0: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+            ASIC1: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_FAILED_ROUTES: {
+            ASIC0: {
+                "10.10.196.200/31": [
+                    {
+                        "prefix": "10.10.196.200/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "failed": True,
+                    },
+                ],
+            },
+            ASIC1: {}
+        },
+        RESULT: {
+            ASIC0: {
+                "failed_FRR_routes": [
+                    {
+                        "prefix": "10.10.196.200/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "failed": True,
+                    },
+                ]
+            }
+        }
+    },
+    "26": {
+        DESCR: "multi-asic with failed FRR routes on specific asic",
+        MULTI_ASIC: True,
+        NAMESPACE: ['asic0', 'asic1'],
+        ARGS: "route_check -n asic1 -m INFO -i 1000",
+        RET: -1,
+        PRE: {
+            ASIC1: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_FAILED_ROUTES: {
+            ASIC1: {
+                "10.10.196.201/31": [
+                    {
+                        "prefix": "10.10.196.201/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "failed": True,
+                    },
+                ],
+            }
+        },
+        RESULT: {
+            ASIC1: {
+                "failed_FRR_routes": [
+                    {
+                        "prefix": "10.10.196.201/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "failed": True,
+                    },
+                ]
+            }
+        }
+    },
+    "27": {
+        DESCR: "single-asic skip failed routes check for non-selected routes",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_FAILED_ROUTES: {
+            DEFAULTNS: {
+                "10.10.196.100/31": [
+                    {
+                        "prefix": "10.10.196.100/31",
+                        "vrfName": "default",
+                        "protocol": "bgp",
+                        "selected": False,
+                        "failed": True,
+                    },
+                ],
+            }
+        },
+    },
+    "28": {
+        DESCR: "single-asic skip failed routes check for non-default VRF",
+        MULTI_ASIC: False,
+        NAMESPACE: [''],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            DEFAULTNS: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_FAILED_ROUTES: {
+            DEFAULTNS: {
+                "10.10.196.100/31": [
+                    {
+                        "prefix": "10.10.196.100/31",
+                        "vrfName": "Vrf1",
+                        "protocol": "bgp",
+                        "selected": True,
+                        "failed": True,
+                    },
+                ],
+            }
+        },
+    },
+    "29": {
+        DESCR: "multi-asic with empty failed routes (namespace prefix stripped)",
+        MULTI_ASIC: True,
+        NAMESPACE: ['asic0', 'asic1'],
+        ARGS: "route_check -m INFO -i 1000",
+        PRE: {
+            ASIC0: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+            ASIC1: {
+                APPL_DB: {
+                    ROUTE_TABLE: {
+                        "0.0.0.0/0" : { "ifname": "portchannel0" },
+                        "10.10.196.12/31" : { "ifname": "portchannel0" },
+                    },
+                    INTF_TABLE: {
+                        "PortChannel1013:10.10.196.24/31": {},
+                        "PortChannel1023:2603:10b0:503:df4::5d/126": {},
+                        "PortChannel1024": {}
+                    }
+                },
+                ASIC_DB: {
+                    RT_ENTRY_TABLE: {
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.12/31" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "10.10.196.24/32" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "2603:10b0:503:df4::5d/128" + RT_ENTRY_KEY_SUFFIX: {},
+                        RT_ENTRY_KEY_PREFIX + "0.0.0.0/0" + RT_ENTRY_KEY_SUFFIX: {}
+                    }
+                },
+            },
+        },
+        FRR_FAILED_ROUTES: {
+            ASIC0: {},
+            ASIC1: {}
         },
     },
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Enhanced Route_check to detect failed routes in FRR.

#### How I did it
Added a new show command in zebra to display Failed routes only(PR: https://github.com/Azure/sonic-buildimage-msft/pull/1908)..
And in route_check script, use this new command to catch any failed route in FRR. 

#### How to verify it
Ran the new script and verified that script runs fine.

#### Previous command output (if the output of a command-line utility has changed)
NA
#### New command output (if the output of a command-line utility has changed)
NA

Test Logs/Data:

```
admin@str2-7804-lc5-1:/tmp$ show ip route summary
asic0:
Route Source         Routes               FIB  (vrf default)
kernel               68                   68                   
connected            13                   13                   
ebgp                 50566                50566                
ibgp                 478                  478                  
------
Totals               51125                51125                


asic1:
Route Source         Routes               FIB  (vrf default)
kernel               64                   64                   
connected            17                   17                   
ebgp                 33800                33800                
ibgp                 474                  474                  
------
Totals               34355                34355                


admin@str2-7804-lc5-1:/tmp$ show ipv6 route summary
asic0:
Route Source         Routes               FIB  (vrf default)
kernel               68                   68                   
connected            46                   46                   
static               1                    1                    
ebgp                 50566                50566                
ibgp                 479                  479                  
------
Totals               51160                51160                


asic1:
Route Source         Routes               FIB  (vrf default)
kernel               64                   64                   
connected            38                   38                   
static               1                    1                    
ebgp                 33800                33800                
ibgp                 475                  475                  
------
Totals               34378                34378                


admin@str2-7804-lc5-1:/tmp$ 
admin@str2-7804-lc5-1:/tmp$ 
admin@str2-7804-lc5-1:/tmp$ 
admin@str2-7804-lc5-1:/tmp$ time show ip route -n asic1 json failed
asic1:
{
}


real    0m0.898s
user    0m0.619s
sys     0m0.140s
admin@str2-7804-lc5-1:/tmp$ time show ip route -n asic0 json failed
asic0:
{
}


real    0m0.905s
user    0m0.630s
sys     0m0.159s
admin@str2-7804-lc5-1:/tmp$ 
admin@str2-7804-lc5-1:/tmp$ time route_check.py   <<<<<<<<<<< Old Script

real    0m0.720s
user    0m0.482s
sys     0m0.268s
admin@str2-7804-lc5-1:/tmp$ 
admin@str2-7804-lc5-1:/tmp$ 
admin@str2-7804-lc5-1:/tmp$ 
(failed reverse-i-search)`time ': ^Cme show ip route -n asic1 json failed
admin@str2-7804-lc5-1:/tmp$ time /tmp/route_check1.py   <<<< New script

real    0m1.936s
user    0m3.837s
sys     0m0.986s
admin@str2-7804-lc5-1:/tmp$ time /tmp/route_check1.py  -m DEBUG  << New script
Checking routes for namespaces: ['asic0', 'asic1']
ASIC DB asic0 connected
ASIC DB asic1 connected
{
    "ASIC_ROUTE_ENTRY": [
        "0.0.0.0/0",
        "10.0.0.0/31",
        "10.0.0.0/32",
        "10.0.0.100/31",
        "10.0.0.102/31",
        "10.0.0.104/31",
        "10.0.0.106/31",
        "10.0.0.108/31",
        "10.0.0.110/31",
        "10.0.0.112/31",
        "10.0.0.114/31",
        "10.0.0.116/31",
        "10.0.0.118/31",
        "10.0.0.12/31",
        "10.0.0.12/32",
        "10.0.0.120/31",
        "10.0.0.122/31",
        "10.0.0.124/31",
        "10.0.0.126/31",
        "10.0.0.128/31",
        "10.0.0.132/31",
        "10.0.0.136/31",
        "10.0.0.140/31",
        "10.0.0.144/31",
        "10.0.0.148/31",
        "10.0.0.152/31",
        "10.0.0.156/31",
        "10.0.0.16/31",
        "10.0.0.16/32",
        "10.0.0.160/31",
        "10.0.0.162/31",
        "10.0.0.164/31",
        "10.0.0.166/31",
        "10.0.0.168/31",
        "10.0.0.170/31",
        "10.0.0.172/31",
        "10.0.0.174/31",
        "10.0.0.176/31",
        "10.0.0.178/31",
        "
APPL DB connected for routes
{
    "ROUTE_TABLE": [
        "0.0.0.0/0",
        "10.0.0.0/31",
        "10.0.0.100/31",
        "10.0.0.101/32",
        "10.0.0.102/31",
        "10.0.0.103/32",
        "10.0.0.104/31",
        "10.0.0.105/32",
        "10.0.0.106/31",
        "10.0.0.107/32",
        "10.0.0.108/31",
        "10.0.0.109/32",
        "10.0.0.110/31",
        "10.0.0.111/32",
        "10.0.0.112/31",
        "10.0.0.113/32",
        "10.0.0.114/31",
        "10.0.0.115/32",
        "10.0.0.116/31",
        "10.0.0.117/32",
        "10.0.0.118/31",
        "10.0.0.119/32",
        "10.0.0.12/31",
        "10.0.0.120/31",
        "10.0.0.121/32",
        "10.0.0.122/31",
        "10.0.0.123/32",
        "10.0.0.124/31",
        "10.0.0.125/32",
        "10.0.0.126/31",
        "10.0.0.127/32",
        "10.0.0.128/31",
        "10.0.0.129/32",
        "10.0.0.132/31",
        "10.0.0.133/32",
        "10.0.0.136/31",
        "10.0.0.137/32",
        "10.0.0.140/31",
        "10.0.0.141/32",
        "
APPL DB connected for interfaces
{
    "APPL_DB_INTF": [
        "10.0.0.0/32",
        "10.0.0.12/32",
        "10.0.0.16/32",
        "10.0.0.20/32",
        "10.0.0.24/32",
        "10.0.0.28/32",
        "10.0.0.32/32",
        "10.0.0.34/32",
        "10.0.0.4/32",
        "10.0.0.8/32",
        "10.1.0.1/32",
        "192.0.0.2/32",
        "2603:10e2:400::2/128",
        "3.3.3.2/32",
        "3333::3:2/128",
        "fc00:10::1/128",
        "fc00::1/128",
        "fc00::11/128",
        "fc00::19/128",
        "fc00::21/128",
        "fc00::29/128",
        "fc00::31/128",
        "fc00::39/128",
        "fc00::41/128",
        "fc00::45/128",
        "fc00::9/128"
    ]
}
{
    "ASIC_ROUTE_ENTRY": [
        "0.0.0.0/0",
        "10.0.0.0/31",
        "10.0.0.100/31",
        "10.0.0.102/31",
        "10.0.0.104/31",
        "10.0.0.106/31",
        "10.0.0.108/31",
        "10.0.0.110/31",
        "10.0.0.112/31",
        "10.0.0.114/31",
        "10.0.0.116/31",
        "10.0.0.118/31",
        "10.0.0.12/31",
        "10.0.0.120/31",
        "10.0.0.122/31",
        "10.0.0.124/31",
        "10.0.0.126/31",
        "10.0.0.128/31",
        "10.0.0.132/31",
        "10.0.0.136/31",
        "10.0.0.140/31",
        "10.0.0.144/31",
        "10.0.0.148/31",
        "10.0.0.152/31",
        "10.0.0.156/31",
        "10.0.0.16/31",
        "10.0.0.160/31",
        "10.0.0.162/31",
        "10.0.0.164/31",
        "10.0.0.166/31",
        "10.0.0.168/31",
        "10.0.0.170/31",
        "10.0.0.172/31",
        "10.0.0.174/31",
        "10.0.0.176/31",
        "10.0.0.178/31",
        "10.0.0.180/31",
        "10.0.0.182/31",
        "10.0.0.184/31",
     
APPL DB connected for routes
{
    "ROUTE_TABLE": [
        "0.0.0.0/0",
        "10.0.0.0/31",
        "10.0.0.1/32",
        "10.0.0.100/31",
        "10.0.0.101/32",
        "10.0.0.102/31",
        "10.0.0.103/32",
        "10.0.0.104/31",
        "10.0.0.105/32",
        "10.0.0.106/31",
        "10.0.0.107/32",
        "10.0.0.108/31",
        "10.0.0.109/32",
        "10.0.0.110/31",
        "10.0.0.111/32",
        "10.0.0.112/31",
        "10.0.0.113/32",
        "10.0.0.114/31",
        "10.0.0.115/32",
        "10.0.0.116/31",
        "10.0.0.117/32",
        "10.0.0.118/31",
        "10.0.0.119/32",
        "10.0.0.12/31",
        "10.0.0.120/31",
        "10.0.0.121/32",
        "10.0.0.122/31",
        "10.0.0.123/32",
        "10.0.0.124/31",
        "10.0.0.125/32",
        "10.0.0.126/31",
        "10.0.0.127/32",
        "10.0.0.128/31",
        "10.0.0.129/32",
        "10.0.0.13/32",
        "10.0.0.132/31",
        "10.0.0.133/32",
        "10.0.0.136/31",
        "10.0.0.137/32",
        "10.
APPL DB connected for interfaces
{
    "APPL_DB_INTF": [
        "10.0.0.36/32",
        "10.0.0.38/32",
        "10.0.0.40/32",
        "10.0.0.42/32",
        "10.0.0.44/32",
        "10.0.0.46/32",
        "10.0.0.48/32",
        "10.0.0.50/32",
        "10.0.0.52/32",
        "10.0.0.54/32",
        "10.0.0.56/32",
        "10.0.0.58/32",
        "10.0.0.60/32",
        "10.0.0.62/32",
        "10.1.0.1/32",
        "192.0.0.3/32",
        "2603:10e2:400::3/128",
        "3.3.3.3/32",
        "3333::3:3/128",
        "fc00:10::1/128",
        "fc00::49/128",
        "fc00::4d/128",
        "fc00::51/128",
        "fc00::55/128",
        "fc00::59/128",
        "fc00::5d/128",
        "fc00::61/128",
        "fc00::65/128",
        "fc00::69/128",
        "fc00::6d/128",
        "fc00::71/128",
        "fc00::75/128",
        "fc00::79/128",
        "fc00::7d/128"
    ]
}
FRR Failed Routes: namespace=asic1, routes={}
FRR failed routes: []
FRR Failed Routes: namespace=asic0, routes={}
FRR failed routes: []
All good!
ret=0, res=None

real    0m1.900s
user    0m3.735s
sys     0m1.045s
admin@str2-7804-lc5-1:/tmp$ 
```
Signed-off by: Deepak Singhal [<deepsinghal@microsoft.com>]
