### PR TITLE
[VS][UT_issue] Fix vs build UT test issue

### DIFF
--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -292,14 +292,6 @@ class TestGetAsicName(unittest.TestCase):
     
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
-    def test_get_asic_td4(self, mock_popen, mock_get_sonic_version_info):
-        mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
-        mock_popen.return_value = mock.Mock()
-        mock_popen.return_value.communicate.return_value = ["Nokia-IXR7220-D4-36D", 0]
-        self.assertEqual(fov.get_asic_name(), "td4")
-
-    @patch('sonic_py_common.device_info.get_sonic_version_info')
-    @patch('subprocess.Popen')
     def test_get_asic_j2cplus(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
@@ -313,14 +305,6 @@ class TestGetAsicName(unittest.TestCase):
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7800R3-48CQ2-C48", 0]
         self.assertEqual(fov.get_asic_name(), "jr2")
-
-    @patch('sonic_py_common.device_info.get_sonic_version_info')
-    @patch('subprocess.Popen')
-    def test_get_asic_q2cplus(self, mock_popen, mock_get_sonic_version_info):
-        mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
-        mock_popen.return_value = mock.Mock()
-        mock_popen.return_value.communicate.return_value = ["Nokia-IXR7250-X1B", 0]
-        self.assertEqual(fov.get_asic_name(), "q2c+")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
vs image build failed due to the UT test failure.  This issue is introduced by PR https://github.com/Azure/sonic-utilities.msft/pull/250 which mistakenly added two test functions test_get_asic_td4() and test_get_asic_q2cplus() using HWSKUs Nokia-IXR7220-D4-36D and Nokia-IXR7250-X1B.  Since these two HWSKUs are not in these release, hence the build failed on UT.
 
#### How I did it
Fix this build issue by removing these two test functions -- test_get_asic_td4() and test_get_asic_q2cplus()

#### How to verify it
vs image build success.
#### Previous command output (if the output of a command-line utility has changed)
n/a
#### New command output (if the output of a command-line utility has changed)
n/a
