### PR TITLE
Fix empty failed route json parsing case on single asic devices

### DIFF
--- a/scripts/route_check.py
+++ b/scripts/route_check.py
@@ -354,8 +354,9 @@ def fetch_routes(cmd):
         output = subprocess.check_output(cmd, text=True)
         # Strip namespace prefix if present (e.g., "asic1:\n{...}" -> "{...}")
         # The SONiC wrapper script adds "asicN:" prefix for multi-asic
+        # On single ASIC linecards, it may just add ":" prefix
         first_line = output.split('\n')[0].strip() if output else ''
-        if re.match(r'^asic\d+:$', first_line):
+        if re.match(r'^(asic\d+)?:$', first_line):
             first_newline = output.find('\n')
             if first_newline != -1:
                 output = output[first_newline + 1:]


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
On Single Asic linecards, route_check script failed due to extra ':' in the output.. This PR is to handle this case on single asic LC.

#### How I did it
Currently we strip the first line in the parsing logic that contains asic# etc. Additionaly also strip the first line if it starts with ":" 

#### How to verify it
Ran the route_check script on single asic LC.

##### Test Output###############
DEEPSINGHAL@STG01-0101-0400-01T2-lc05:~$ show ip route json failed
:
{
}

Before Change:
DEEPSINGHAL@STG01-0101-0400-01T2-lc05:~$ route_check.py -m INFO
Checking routes for namespaces: ['']
Failed to parse JSON from command ['show', 'ip', 'route', 'json', 'failed']: Expecting value: line 1 column 1 (char 0)


After Change:
DEEPSINGHAL@STG01-0101-0400-01T2-lc05:~$ route_check.py -m INFO
Checking routes for namespaces: ['']
All good!
