### PR TITLE
[202412][GCU] Update WRED_PROFILE and BUFFER_POOL validators for GCU

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -169,10 +169,6 @@ def buffer_profile_config_update_validator(patch_element):
     return rdma_config_update_validator_common(patch_element)
 
 
-def wred_profile_config_update_validator(patch_element):
-    return rdma_config_update_validator_common(patch_element)
-
-
 def read_statedb_entry(table, key, field):
     state_db = swsscommon.DBConnector("STATE_DB", 0)
     tbl = swsscommon.Table(state_db, table)

--- a/generic_config_updater/gcu_field_operation_validators.conf.json
+++ b/generic_config_updater/gcu_field_operation_validators.conf.json
@@ -78,26 +78,9 @@
                 "rdma_config_update_validator": {
                     "Shared/headroom pool size changes": {
                         "fields": [
-                            "ingress_lossless_pool/xoff",
-                            "ingress_lossless_pool/size",
-                            "egress_lossy_pool/size"
                         ],
-                        "operations": ["replace"],
+                        "operations": [],
                         "platforms": {
-                            "spc1": "20191100",
-			    "spc2": "20191100",
-                            "spc3": "20220500",
-                            "spc4": "20221100",
-                            "spc5": "20241200",
-                            "td2": "",
-                            "th": "20221100",
-                            "th2": "20221100",
-                            "th3": "20240500",
-                            "th4": "20240500",
-                            "th5": "20240500",
-                            "td3": "20221100",
-                            "j2c+": "20220500",
-                            "cisco-8000": "20201200"
                         }
                     }
                 }
@@ -169,37 +152,6 @@
                             "spc4": "20241200",
                             "spc5": "20241200",
                             "th5": "20241200"
-                        }
-                    }
-                }
-            }
-        },
-        "WRED_PROFILE": {
-            "field_operation_validators": [ "generic_config_updater.field_operation_validators.wred_profile_config_update_validator" ],
-            "validator_data": {
-                "rdma_config_update_validator": {
-                    "ECN tuning": {
-                        "fields": [
-                            "green_min_threshold",
-                            "green_max_threshold",
-                            "green_drop_probability"
-                        ],
-                        "operations": ["replace"],
-                        "platforms": {
-                            "spc1": "20181100",
-                            "spc2": "20191100",
-                            "spc3": "20220500",
-                            "spc4": "20221100",
-                            "spc5": "20241200",
-                            "td2": "20181100",
-                            "th": "20181100",
-                            "th2": "20181100",
-                            "th3": "20240500",
-                            "th4": "20240500",
-                            "th5": "20240500",
-                            "td3": "20201200",
-                            "j2c+": "20220500",
-                            "cisco-8000": "20201200"
                         }
                     }
                 }

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -182,6 +182,44 @@ class TestValidateFieldOperation:
         target_config = {"PFC_WD": {"GLOBAL": {}}}
         config_wrapper = gu_common.ConfigWrapper()
         pytest.raises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
+    
+    @patch("sonic_py_common.device_info.get_sonic_version_info",
+           mock.Mock(return_value={"build_version": "20241211.49"}))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
+    @patch("os.path.exists", mock.Mock(return_value=True))
+    @patch(
+        "builtins.open",
+        mock_open(
+            read_data=(
+                '{"tables": {"BUFFER_POOL": {'
+                '"field_operation_validators": ['
+                '"generic_config_updater.field_operation_validators.rdma_config_update_validator"'
+                '], "validator_data": {"rdma_config_update_validator": {"Blocked ops": '
+                '{"fields": ["ingress_lossless_pool/xoff", '
+                '"ingress_lossless_pool/size", "egress_lossy_pool/size"], '
+                '"operations": [], "platforms": {"spc1": "20181100"}}}}}}}'
+            )
+        )
+    )
+    def test_validate_field_operation_illegal__buffer_pool(self):
+        old_config = {
+            "BUFFER_POOL": {
+                "ingress_lossless_pool": {"xoff": "1000"}
+            }
+        }
+        target_config = {
+            "BUFFER_POOL": {
+                "ingress_lossless_pool": {"xoff": "2000"}
+            }
+        }
+        config_wrapper = gu_common.ConfigWrapper()
+        pytest.raises(
+            gu_common.IllegalPatchOperationError,
+            config_wrapper.validate_field_operation,
+            old_config,
+            target_config
+        )
 
     def test_validate_field_operation_legal__rm_loopback1(self):
         old_config = {

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -177,87 +177,6 @@ class TestValidateFieldOperation:
         patch_element = {"path": "/PFC_WD/Ethernet8/other_field", "op": "add", "value": "sample_value"}
         assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
 
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "20250530.12"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="th5"))
-    @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"WRED_PROFILE": {"validator_data": {"rdma_config_update_validator": {"ECN tuning": {"fields": ["green_min_threshold", "green_max_threshold", "green_drop_probability"], "operations": ["replace"], "platforms": {"th5": "20240500"}}}}}}}'))
-    def test_wred_profile_config_update_validator_lossless(self):
-        patch_element = {
-            "path": "/WRED_PROFILE/AZURE_LOSSLESS/green_min_threshold",
-            "op": "replace",
-            "value": "1234"
-        }
-        assert generic_config_updater.field_operation_validators.wred_profile_config_update_validator(patch_element) == True
-
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "20250530.12"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="th5"))
-    @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"WRED_PROFILE": {"validator_data": {"rdma_config_update_validator": {"ECN tuning": {"fields": ["green_min_threshold", "green_max_threshold", "green_drop_probability"], "operations": ["replace"], "platforms": {"th5": "20240500"}}}}}}}'))
-    def test_wred_profile_config_update_validator_lossy(self):
-        patch_element = {
-            "path": "/WRED_PROFILE/AZURE_LOSSY/green_min_threshold",
-            "op": "replace",
-            "value": "1234"
-        }
-        assert generic_config_updater.field_operation_validators.wred_profile_config_update_validator(patch_element) == True
-
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "20250530.12"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="th5"))
-    @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"WRED_PROFILE": {"validator_data": {"rdma_config_update_validator": {"ECN tuning": {"fields": ["green_min_threshold", "green_max_threshold", "green_drop_probability"], "operations": ["replace"], "platforms": {"th5": "20240500"}}}}}}}'))
-    def test_wred_profile_config_update_validator_invalid_field(self):
-        patch_element = {
-            "path": "/WRED_PROFILE/AZURE_LOSSY/invalid",
-            "op": "replace",
-            "value": "1234"
-        }
-        assert generic_config_updater.field_operation_validators.wred_profile_config_update_validator(patch_element) == False
-
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="unknown"))
-    def test_wred_profile_config_update_validator_unknown_asic(self):
-        patch_element = {
-            "path": "/WRED_PROFILE/AZURE_LOSSY/green_min_threshold",
-            "op": "replace",
-            "value": "1234"
-        }
-        assert generic_config_updater.field_operation_validators.wred_profile_config_update_validator(patch_element) == False
-
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="th5"))
-    @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"WRED_PROFILE": {"validator_data": {"rdma_config_update_validator": {"ECN tuning": {"fields": ["green_min_threshold", "green_max_threshold", "green_drop_probability"], "operations": ["replace"], "platforms": {"th5": "20240500"}}}}}}}'))
-    def test_wred_profile_config_update_validator_old_version(self):
-        patch_element = {
-            "path": "/WRED_PROFILE/AZURE_LOSSY/green_min_threshold",
-            "op": "replace",
-            "value": "1234"
-        }
-        assert generic_config_updater.field_operation_validators.wred_profile_config_update_validator(patch_element) == False
-
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "20250530.12"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="th5"))
-    @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"WRED_PROFILE": {"validator_data": {"rdma_config_update_validator": {"ECN tuning": {"fields": ["green_min_threshold", "green_max_threshold", "green_drop_probability"], "operations": ["replace"], "platforms": {"th5": "20240500"}}}}}}}'))
-    def test_wred_profile_config_update_validator_invalid_op(self):
-        patch_element = {
-            "path": "/WRED_PROFILE/AZURE_LOSSY/green_min_threshold",
-            "op": "add",
-            "value": "1234"
-        }
-        assert generic_config_updater.field_operation_validators.wred_profile_config_update_validator(patch_element) == False
-
-    @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "20250530.12"}))
-    @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
-    @patch("os.path.exists", mock.Mock(return_value=True))
-    @patch("builtins.open", mock_open(read_data='{"tables": {"WRED_PROFILE": {"validator_data": {"rdma_config_update_validator": {"ECN tuning": {"fields": ["green_min_threshold", "green_max_threshold", "green_drop_probability"], "operations": ["replace"], "platforms": {"th5": "20240500"}}}}}}}'))
-    def test_wred_profile_config_update_validator_invalid_asic(self):
-        patch_element = {
-            "path": "/WRED_PROFILE/AZURE_LOSSY/green_min_threshold",
-            "op": "replace",
-            "value": "1234"
-        }
-        assert generic_config_updater.field_operation_validators.wred_profile_config_update_validator(patch_element) == False
-
     def test_validate_field_operation_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
         target_config = {"PFC_WD": {"GLOBAL": {}}}
@@ -382,6 +301,150 @@ class TestValidateFieldOperation:
                 }
             }
         }
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+
+    @pytest.mark.parametrize(
+        "field,old_value,new_value,op", [
+            ("ecn", "ecn_all", "ecn_green", "replace"),
+            ("green_drop_probability", "5", "6", "replace"),
+            ("green_max_threshold", "136200192", "136200193", "replace"),
+            ("green_min_threshold", "136200192", "136200193", "replace"),
+            ("red_drop_probability", "5", "6", "replace"),
+            ("red_max_threshold", "282624", "282625", "replace"),
+            ("red_min_threshold", "166912", "166913", "replace"),
+            ("wred_green_enable", "false", "true", "replace"),
+            ("wred_red_enable", "false", "true", "replace"),
+            ("wred_yellow_enable", "false", "true", "replace"),
+            ("yellow_drop_probability", "5", "6", "replace"),
+            ("yellow_max_threshold", "282624", "282625", "replace"),
+            ("yellow_min_threshold", "166912", "166913", "replace")
+        ]
+    )
+    def test_validate_field_operation_wred_profile_replace(self, field, old_value, new_value, op):
+        old_config = {"WRED_PROFILE": {"AZURE_LOSSY": {field: old_value}}}
+        target_config = {"WRED_PROFILE": {"AZURE_LOSSY": {field: new_value}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    @pytest.mark.parametrize(
+        "field,value", [
+            ("green_min_threshold", "1200"),
+            ("yellow_max_threshold", "2400"),
+            ("red_min_threshold", "3200"),
+            ("green_drop_probability", "10"),
+            ("wred_green_enable", "true"),
+            ("wred_yellow_enable", "true"),
+            ("wred_red_enable", "true")
+        ]
+    )
+    def test_validate_field_operation_wred_profile_add(self, field, value):
+        old_config = {"WRED_PROFILE": {"AZURE_LOSSY": {}}}
+        target_config = {"WRED_PROFILE": {"AZURE_LOSSY": {field: value}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    @pytest.mark.parametrize(
+        "table", [
+            "BUFFER_PORT_EGRESS_PROFILE_LIST",
+            "BUFFER_PORT_INGRESS_PROFILE_LIST"
+        ]
+    )
+    def test_validate_field_operation_buffer_port_profile_list_add(self, table):
+        old_config = {table: {"Ethernet0": {}}}
+        target_config = {table: {"Ethernet0": {"profile_list": "AZURE_PROFILE"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    @pytest.mark.parametrize(
+        "table", [
+            "BUFFER_PORT_EGRESS_PROFILE_LIST",
+            "BUFFER_PORT_INGRESS_PROFILE_LIST"
+        ]
+    )
+    def test_validate_field_operation_buffer_port_profile_list_replace(self, table):
+        old_config = {table: {"Ethernet0": {"profile_list": "AZURE_PROFILE"}}}
+        target_config = {table: {"Ethernet0": {"profile_list": "NEW_PROFILE"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    @pytest.mark.parametrize(
+        "table", [
+            "BUFFER_PORT_EGRESS_PROFILE_LIST",
+            "BUFFER_PORT_INGRESS_PROFILE_LIST"
+        ]
+    )
+    def test_validate_field_operation_buffer_port_profile_list_remove(self, table):
+        old_config = {table: {"Ethernet0": {"profile_list": "AZURE_PROFILE"}}}
+        target_config = {table: {"Ethernet0": {}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_queue_scheduler_replace(self):
+        old_config = {"QUEUE": {"Ethernet0|0": {"scheduler": "sched0"}}}
+        target_config = {"QUEUE": {"Ethernet0|0": {"scheduler": "sched1"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_queue_wred_profile_add(self):
+        old_config = {"QUEUE": {"Ethernet0|1": {}}}
+        target_config = {"QUEUE": {"Ethernet0|1": {"wred_profile": "WRED_PROFILE"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_queue_wred_profile_replace(self):
+        old_config = {"QUEUE": {"Ethernet0|1": {"wred_profile": "WRED_PROFILE"}}}
+        target_config = {"QUEUE": {"Ethernet0|1": {"wred_profile": "WRED_PROFILE_NEW"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    @pytest.mark.parametrize(
+        "field,new_value", [
+            ("dscp_to_tc_map", "AZURE"),
+            ("tc_to_pg_map", "AZURE"),
+            ("tc_to_queue_map", "AZURE")
+        ]
+    )
+    def test_validate_field_operation_port_qos_map_replace(self, field, new_value):
+        old_config = {"PORT_QOS_MAP": {"Ethernet0": {field: "DEFAULT"}}}
+        target_config = {"PORT_QOS_MAP": {"Ethernet0": {field: new_value}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_port_qos_map_tc_to_dscp_add(self):
+        old_config = {"PORT_QOS_MAP": {"Ethernet0": {}}}
+        target_config = {"PORT_QOS_MAP": {"Ethernet0": {"tc_to_dscp_map": "AZURE"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_port_qos_map_tc_to_dscp_replace(self):
+        old_config = {"PORT_QOS_MAP": {"Ethernet0": {"tc_to_dscp_map": "DEFAULT"}}}
+        target_config = {"PORT_QOS_MAP": {"Ethernet0": {"tc_to_dscp_map": "AZURE"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_port_qos_map_dscp_to_tc_replace(self):
+        old_config = {"PORT_QOS_MAP": {"Ethernet0": {"dscp_to_tc_map": "DEFAULT"}}}
+        target_config = {"PORT_QOS_MAP": {"Ethernet0": {"dscp_to_tc_map": "AZURE"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_port_qos_map_tc_to_pg_replace(self):
+        old_config = {"PORT_QOS_MAP": {"Ethernet0": {"tc_to_pg_map": "DEFAULT"}}}
+        target_config = {"PORT_QOS_MAP": {"Ethernet0": {"tc_to_pg_map": "AZURE"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_port_qos_map_tc_to_queue_replace(self):
+        old_config = {"PORT_QOS_MAP": {"Ethernet0": {"tc_to_queue_map": "DEFAULT"}}}
+        target_config = {"PORT_QOS_MAP": {"Ethernet0": {"tc_to_queue_map": "AZURE"}}}
+        config_wrapper = gu_common.ConfigWrapper()
+        config_wrapper.validate_field_operation(old_config, target_config)
+
+    def test_validate_field_operation_scheduler_weight_replace(self):
+        old_config = {"SCHEDULER": {"scheduler.0": {"weight": "10", "type": "DWRR"}}}
+        target_config = {"SCHEDULER": {"scheduler.0": {"weight": "20", "type": "DWRR"}}}
         config_wrapper = gu_common.ConfigWrapper()
         config_wrapper.validate_field_operation(old_config, target_config)
 

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -214,12 +214,25 @@ class TestValidateFieldOperation:
             }
         }
         config_wrapper = gu_common.ConfigWrapper()
-        pytest.raises(
-            gu_common.IllegalPatchOperationError,
-            config_wrapper.validate_field_operation,
-            old_config,
-            target_config
-        )
+        original_validator = fov.rdma_config_update_validator
+
+        def _rdma_validator_wrapper(*args, **kwargs):
+            if args:
+                patch_element = args[-1]
+            else:
+                patch_element = kwargs.get("patch_element")
+            return original_validator(patch_element)
+
+        with patch(
+            "generic_config_updater.field_operation_validators.rdma_config_update_validator",
+            side_effect=_rdma_validator_wrapper,
+        ):
+            pytest.raises(
+                gu_common.IllegalPatchOperationError,
+                config_wrapper.validate_field_operation,
+                old_config,
+                target_config
+            )
 
     def test_validate_field_operation_legal__rm_loopback1(self):
         old_config = {


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
CP of [#4219](https://github.com/sonic-net/sonic-utilities/pull/4219)
#### How I did it

#### How to verify it
Tested locally

```
tests/generic_config_updater/field_operation_validator_test.py ...........................................................................................             [100%]

============================================================================= 91 passed in 0.13s ============================================================================
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

