### PR TITLE
add reboot cause formatter

### DIFF
--- a/show_gnmi_util/README.md
+++ b/show_gnmi_util/README.md
@@ -1,0 +1,41 @@
+﻿# Show GNMI Util - JSON to Tabular Format Converter
+
+This package provides formatters to convert JSON output from show commands into tabular CLI format.
+
+## Structure
+
+show_gnmi_util/ 
+├── common/# Common utilities and base classes 
+├── formatter/           # Command-specific formatters 
+├── scripts/             # Sample JSON files and CLI tool 
+└── test/                # Unit tests
+
+## Supported Commands
+
+- `show version`
+- `show vlan brief`
+
+## Usage
+
+### Command Line
+python show_gnmi_util/scripts/show_arm_cli.py
+
+
+### In Code
+from show_gnmi_util.formatter import ShowVersionFormatter, ShowVlanBriefFormatter
+Format show version
+formatter = ShowVersionFormatter() output = formatter.format(json_data) print(output)
+Format show vlan brief
+vlan_formatter = ShowVlanBriefFormatter() vlan_output = vlan_formatter.format(vlan_json_data) print(vlan_output)
+
+
+## Testing
+python -m unittest show_gnmi_util/test/test_formatters.py
+
+
+## Adding New Formatters
+
+1. Create a new formatter class in `formatter/` directory
+2. Extend `BaseFormatter` class
+3. Implement the `format()` method
+4. Add unit tests in `test/` directory

--- a/show_gnmi_util/README.md
+++ b/show_gnmi_util/README.md
@@ -5,7 +5,7 @@ This package provides formatters to convert JSON output from show commands into 
 ## Structure
 
 show_gnmi_util/ 
-├── common/# Common utilities and base classes 
+├── common/              # Common utilities and base classes 
 ├── formatter/           # Command-specific formatters 
 ├── scripts/             # Sample JSON files and CLI tool 
 └── test/                # Unit tests

--- a/show_gnmi_util/common/__init__.py
+++ b/show_gnmi_util/common/__init__.py
@@ -1,0 +1,3 @@
+"""
+Common utilities for formatters
+"""

--- a/show_gnmi_util/common/base_formatter.py
+++ b/show_gnmi_util/common/base_formatter.py
@@ -1,0 +1,53 @@
+﻿"""
+Base formatter class for converting JSON to tabular format
+"""
+
+from abc import ABC, abstractmethod
+from typing import Dict, List, Any
+
+
+class BaseFormatter(ABC):
+    """
+    Abstract base class for all formatters
+    """
+    
+    def __init__(self):
+        self.output_lines = []
+    
+    @abstractmethod
+    def format(self, json_data: Dict[str, Any]) -> str:
+        """
+        Convert JSON data to tabular format
+        
+        Args:
+            json_data: Dictionary containing the JSON data
+            
+        Returns:
+            Formatted string in tabular format
+        """
+        pass
+    
+    def _add_line(self, line: str = ""):
+        """Add a line to the output"""
+        self.output_lines.append(line)
+    
+    def _add_separator(self):
+        """Add a separator line"""
+        self._add_line()
+    
+    def _add_header(self, title: str):
+        """Add a header with underline"""
+        self._add_line(title)
+        self._add_line()
+    
+    def _format_key_value(self, key: str, value: str, separator: str = ": ") -> str:
+        """Format a key-value pair"""
+        return f"{key}{separator}{value}"
+    
+    def _get_output(self) -> str:
+        """Get the formatted output as a string"""
+        return "\n".join(self.output_lines)
+    
+    def _clear_output(self):
+        """Clear the output buffer"""
+        self.output_lines = []

--- a/show_gnmi_util/formatter/__init__.py
+++ b/show_gnmi_util/formatter/__init__.py
@@ -4,5 +4,7 @@ Formatters for different show commands
 
 from .show_version_formatter import ShowVersionFormatter
 from .show_vlan_brief_formatter import ShowVlanBriefFormatter
+from .show_reboot_cause_formatter import ShowRebootCauseFormatter, ShowRebootCauseHistoryFormatter
 
-__all__ = ['ShowVersionFormatter', 'ShowVlanBriefFormatter']
+__all__ = ['ShowVersionFormatter', 'ShowVlanBriefFormatter', 'ShowRebootCauseFormatter', 'ShowRebootCauseHistoryFormatter']
+

--- a/show_gnmi_util/formatter/__init__.py
+++ b/show_gnmi_util/formatter/__init__.py
@@ -1,0 +1,8 @@
+﻿"""
+Formatters for different show commands
+"""
+
+from .show_version_formatter import ShowVersionFormatter
+from .show_vlan_brief_formatter import ShowVlanBriefFormatter
+
+__all__ = ['ShowVersionFormatter', 'ShowVlanBriefFormatter']

--- a/show_gnmi_util/formatter/show_reboot_cause_formatter.py
+++ b/show_gnmi_util/formatter/show_reboot_cause_formatter.py
@@ -1,0 +1,122 @@
+"""
+Formatters for 'show reboot cause' and 'show reboot cause history' commands
+"""
+
+from typing import Dict, Any, List
+from tabulate import tabulate
+from ..common.base_formatter import BaseFormatter
+
+
+class ShowRebootCauseFormatter(BaseFormatter):
+    """
+    Format 'show reboot cause' JSON output to tabular format
+    """
+    
+    def __init__(self):
+        super().__init__()
+        self.field_mappings = {
+            'gen_time': 'Generation Time',
+            'cause': 'Cause',
+            'user': 'User', 
+            'time': 'Time',
+            'comment': 'Comment'
+        }
+    
+    def format(self, json_data: Dict[str, Any]) -> str:
+        """
+        Convert show reboot cause data to tabular format
+        
+        Args:
+            json_data: JSON data containing reboot cause information
+            
+        Returns:
+            Formatted string in tabular format
+        """
+        self._clear_output()
+        
+        if not json_data:
+            self._add_line("No reboot cause information available")
+            return self._get_output()
+        
+        # Format reboot cause information
+        self._add_line("Previous reboot cause:")
+        self._add_separator()
+        
+        for json_key, display_name in self.field_mappings.items():
+            value = json_data.get(json_key, 'N/A')
+            
+            # Handle None, empty values, or "N/A" strings
+            if value is None or value == '' or value == 'N/A':
+                value = 'N/A'
+            
+            self._add_line(self._format_key_value(display_name, str(value)))
+        
+        return self._get_output()
+
+
+class ShowRebootCauseHistoryFormatter(BaseFormatter):
+    """
+    Format 'show reboot cause history' JSON output to tabular format
+    """
+    
+    def format(self, json_data: Dict[str, Any]) -> str:
+        """
+        Convert show reboot cause history data to tabular format
+        
+        Args:
+            json_data: JSON data containing reboot cause history information
+            
+        Returns:
+            Formatted string in tabular format
+        """
+        self._clear_output()
+        
+        if not json_data:
+            self._add_line("No reboot cause history available")
+            return self._get_output()
+        
+        # Format reboot cause history as table
+        table_output = self._build_reboot_history_table(json_data)
+        self._add_line(table_output)
+        
+        return self._get_output()
+    
+    def _build_reboot_history_table(self, history_data: Dict[str, Any]) -> str:
+        """
+        Build reboot cause history table from JSON data using tabulate
+        
+        Args:
+            history_data: Dictionary with reboot cause history information
+            
+        Returns:
+            Formatted table string
+        """
+        # Define headers
+        headers = ['Name', 'Cause', 'Time', 'User', 'Comment']
+        
+        # Prepare rows
+        table_data = []
+        
+        for entry_name, entry_data in history_data.items():
+            if isinstance(entry_data, dict):
+                cause = entry_data.get('cause', 'N/A')
+                time = entry_data.get('time', 'N/A')
+                user = entry_data.get('user', 'N/A')
+                comment = entry_data.get('comment', 'N/A')
+                
+                # Handle None, empty values, or "N/A" strings
+                cause = 'N/A' if not cause or cause == 'N/A' else str(cause)
+                time = 'N/A' if not time or time == 'N/A' else str(time)
+                user = 'N/A' if not user or user == 'N/A' else str(user)
+                comment = 'N/A' if not comment or comment == 'N/A' else str(comment)
+                
+                table_data.append([entry_name, cause, time, user, comment])
+        
+        if not table_data:
+            return "No reboot cause history entries found"
+        
+        # Sort by entry name for consistent output
+        table_data.sort(key=lambda x: x[0])
+        
+        # Use tabulate to format the table
+        return tabulate(table_data, headers=headers, tablefmt='simple')

--- a/show_gnmi_util/formatter/show_version_formatter.py
+++ b/show_gnmi_util/formatter/show_version_formatter.py
@@ -3,6 +3,7 @@ Formatter for 'show version' command
 """
 
 from typing import Dict, Any, List
+from tabulate import tabulate
 from ..common.base_formatter import BaseFormatter
 
 
@@ -69,7 +70,7 @@ class ShowVersionFormatter(BaseFormatter):
     
     def _format_docker_table(self, docker_images: List[Dict[str, str]]) -> str:
         """
-        Format docker images as a table
+        Format docker images as a table using tabulate
         
         Args:
             docker_images: List of docker image dictionaries
@@ -80,59 +81,22 @@ class ShowVersionFormatter(BaseFormatter):
         if not docker_images:
             return ""
         
-        # Define column headers and widths
+        # Prepare table data
         headers = ['REPOSITORY', 'TAG', 'IMAGE ID', 'SIZE']
+        table_data = []
         
-        # Calculate column widths
-        col_widths = {
-            'REPOSITORY': len('REPOSITORY'),
-            'TAG': len('TAG'),
-            'IMAGE ID': len('IMAGE ID'),
-            'SIZE': len('SIZE')
-        }
-        
-        # Update widths based on data
-        for image in docker_images:
-            col_widths['REPOSITORY'] = max(col_widths['REPOSITORY'], len(image.get('Repository', '')))
-            col_widths['TAG'] = max(col_widths['TAG'], len(image.get('Tag', '')))
-            
-            # Extract short image ID (first 12 chars after sha256:)
-            image_id = image.get('ID', '')
-            if image_id.startswith('sha256:'):
-                image_id = image_id[7:19]
-            col_widths['IMAGE ID'] = max(col_widths['IMAGE ID'], len(image_id))
-            
-            col_widths['SIZE'] = max(col_widths['SIZE'], len(image.get('Size', '')))
-        
-        # Build table
-        table_lines = []
-        
-        # Header line
-        header_line = "{}   {}   {}   {}".format(
-            'REPOSITORY'.ljust(col_widths['REPOSITORY']),
-            'TAG'.ljust(col_widths['TAG']),
-            'IMAGE ID'.ljust(col_widths['IMAGE ID']),
-            'SIZE'.ljust(col_widths['SIZE'])
-        )
-        table_lines.append(header_line)
-        
-        # Data lines
         for image in docker_images:
             repo = image.get('Repository', '')
             tag = image.get('Tag', '')
             image_id = image.get('ID', '')
             size = image.get('Size', '')
             
-            # Extract short image ID
+            # Extract short image ID (first 12 chars after sha256:)
             if image_id.startswith('sha256:'):
                 image_id = image_id[7:19]
             
-            data_line = "{}   {}   {}   {}".format(
-                repo.ljust(col_widths['REPOSITORY']),
-                tag.ljust(col_widths['TAG']),
-                image_id.ljust(col_widths['IMAGE ID']),
-                size.ljust(col_widths['SIZE'])
-            )
-            table_lines.append(data_line)
+            table_data.append([repo, tag, image_id, size])
         
-        return "\n".join(table_lines)
+        # Use tabulate to format the table
+        # 'plain' tablefmt matches the simple format used in show version
+        return tabulate(table_data, headers=headers, tablefmt='plain')

--- a/show_gnmi_util/formatter/show_version_formatter.py
+++ b/show_gnmi_util/formatter/show_version_formatter.py
@@ -1,0 +1,138 @@
+﻿"""
+Formatter for 'show version' command
+"""
+
+from typing import Dict, Any, List
+from ..common.base_formatter import BaseFormatter
+
+
+class ShowVersionFormatter(BaseFormatter):
+    """
+    Format 'show version' JSON output to tabular format
+    """
+    
+    def __init__(self):
+        super().__init__()
+        self.field_mappings = {
+            'sonic_software_version': 'SONiC Software Version',
+            'sonic_os_version': 'SONiC OS Version',
+            'distribution': 'Distribution',
+            'kernel': 'Kernel',
+            'build_commit': 'Build commit',
+            'build_date': 'Build date',
+            'built_by': 'Built by',
+            'platform': 'Platform',
+            'hwsku': 'HwSKU',
+            'asic': 'ASIC',
+            'asic_count': 'ASIC Count',
+            'serial_number': 'Serial Number',
+            'model_number': 'Model Number',
+            'hardware_revision': 'Hardware Revision',
+            'uptime': 'Uptime',
+            'date': 'Date'
+        }
+    
+    def format(self, json_data: Dict[str, Any]) -> str:
+        """
+        Convert show version JSON to tabular format
+        
+        Args:
+            json_data: Dictionary containing show version data
+            
+        Returns:
+            Formatted string in tabular format
+        """
+        self._clear_output()
+        
+        # Add main version information
+        for json_key, display_name in self.field_mappings.items():
+            value = json_data.get(json_key, '')
+            
+            # Handle special cases
+            if value in ['<nil>', '\u003cnil\u003e', None]:
+                value = ''
+            
+            # Skip empty HwSKU
+            if json_key == 'hwsku' and not value:
+                continue
+            
+            self._add_line(self._format_key_value(display_name, str(value)))
+        
+        # Add Docker images section if present
+        docker_images = json_data.get('docker_images', [])
+        if docker_images:
+            self._add_separator()
+            self._add_line("Docker images:")
+            self._add_line(self._format_docker_table(docker_images))
+        
+        return self._get_output()
+    
+    def _format_docker_table(self, docker_images: List[Dict[str, str]]) -> str:
+        """
+        Format docker images as a table
+        
+        Args:
+            docker_images: List of docker image dictionaries
+            
+        Returns:
+            Formatted table string
+        """
+        if not docker_images:
+            return ""
+        
+        # Define column headers and widths
+        headers = ['REPOSITORY', 'TAG', 'IMAGE ID', 'SIZE']
+        
+        # Calculate column widths
+        col_widths = {
+            'REPOSITORY': len('REPOSITORY'),
+            'TAG': len('TAG'),
+            'IMAGE ID': len('IMAGE ID'),
+            'SIZE': len('SIZE')
+        }
+        
+        # Update widths based on data
+        for image in docker_images:
+            col_widths['REPOSITORY'] = max(col_widths['REPOSITORY'], len(image.get('Repository', '')))
+            col_widths['TAG'] = max(col_widths['TAG'], len(image.get('Tag', '')))
+            
+            # Extract short image ID (first 12 chars after sha256:)
+            image_id = image.get('ID', '')
+            if image_id.startswith('sha256:'):
+                image_id = image_id[7:19]
+            col_widths['IMAGE ID'] = max(col_widths['IMAGE ID'], len(image_id))
+            
+            col_widths['SIZE'] = max(col_widths['SIZE'], len(image.get('Size', '')))
+        
+        # Build table
+        table_lines = []
+        
+        # Header line
+        header_line = "{}   {}   {}   {}".format(
+            'REPOSITORY'.ljust(col_widths['REPOSITORY']),
+            'TAG'.ljust(col_widths['TAG']),
+            'IMAGE ID'.ljust(col_widths['IMAGE ID']),
+            'SIZE'.ljust(col_widths['SIZE'])
+        )
+        table_lines.append(header_line)
+        
+        # Data lines
+        for image in docker_images:
+            repo = image.get('Repository', '')
+            tag = image.get('Tag', '')
+            image_id = image.get('ID', '')
+            size = image.get('Size', '')
+            
+            # Extract short image ID
+            if image_id.startswith('sha256:'):
+                image_id = image_id[7:19]
+            
+            data_line = "{}   {}   {}   {}".format(
+                repo.ljust(col_widths['REPOSITORY']),
+                tag.ljust(col_widths['TAG']),
+                image_id.ljust(col_widths['IMAGE ID']),
+                size.ljust(col_widths['SIZE'])
+            )
+            table_lines.append(data_line)
+        
+        return "\n".join(table_lines)

--- a/show_gnmi_util/formatter/show_vlan_brief_formatter.py
+++ b/show_gnmi_util/formatter/show_vlan_brief_formatter.py
@@ -1,0 +1,126 @@
+﻿"""
+Formatter for 'show vlan brief' command
+"""
+
+from typing import Dict, Any, List
+from ..common.base_formatter import BaseFormatter
+
+
+class ShowVlanBriefFormatter(BaseFormatter):
+    """
+    Format 'show vlan brief' JSON output to tabular format
+    """
+    
+    def format(self, json_data: Dict[str, Any]) -> str:
+        """
+        Convert show vlan brief JSON to tabular format
+        
+        Args:
+            json_data: Dictionary containing VLAN data
+            
+        Returns:
+            Formatted string in tabular format
+        """
+        self._clear_output()
+        
+        if not json_data:
+            return "No VLANs configured"
+        
+        # Build table
+        table_output = self._build_vlan_table(json_data)
+        self._add_line(table_output)
+        
+        return self._get_output()
+    
+    def _build_vlan_table(self, vlan_data: Dict[str, Any]) -> str:
+        """
+        Build VLAN table from JSON data
+        
+        Args:
+            vlan_data: Dictionary with VLAN information
+            
+        Returns:
+            Formatted table string
+        """
+        # Define headers
+        headers = ['VLAN', 'IP Address', 'Ports', 'Port Tagging', 'DHCP Helper Address', 'Proxy ARP']
+        
+        # Calculate column widths
+        col_widths = {
+            'VLAN': len('VLAN'),
+            'IP Address': len('IP Address'),
+            'Ports': len('Ports'),
+            'Port Tagging': len('Port Tagging'),
+            'DHCP Helper Address': len('DHCP Helper Address'),
+            'Proxy ARP': len('Proxy ARP')
+        }
+        
+        # Prepare rows
+        rows = []
+        for vlan_name, vlan_info in sorted(vlan_data.items()):
+            vlan_id = vlan_info.get('vlan_id', '')
+            ip_addresses = vlan_info.get('ip_address', [])
+            ports_list = vlan_info.get('ports', [])
+            dhcp_helpers = vlan_info.get('dhcp_helper_addresses', [])
+            proxy_arp = vlan_info.get('proxy_arp', 'disabled')
+            
+            # Handle multiple ports - create separate rows for each port
+            if not ports_list:
+                row = {
+                    'VLAN': vlan_id,
+                    'IP Address': ', '.join(ip_addresses) if ip_addresses else '',
+                    'Ports': '',
+                    'Port Tagging': '',
+                    'DHCP Helper Address': ', '.join(dhcp_helpers) if dhcp_helpers else '',
+                    'Proxy ARP': proxy_arp
+                }
+                rows.append(row)
+            else:
+                for idx, port_info in enumerate(ports_list):
+                    port_name = port_info.get('name', '')
+                    port_tagging = port_info.get('port_tagging', 'untagged')
+                    
+                    if idx == 0:
+                        # First row shows VLAN ID and all info
+                        row = {
+                            'VLAN': vlan_id,
+                            'IP Address': ', '.join(ip_addresses) if ip_addresses else '',
+                            'Ports': port_name,
+                            'Port Tagging': port_tagging,
+                            'DHCP Helper Address': ', '.join(dhcp_helpers) if dhcp_helpers else '',
+                            'Proxy ARP': proxy_arp
+                        }
+                    else:
+                        # Subsequent rows only show port info
+                        row = {
+                            'VLAN': '',
+                            'IP Address': '',
+                            'Ports': port_name,
+                            'Port Tagging': port_tagging,
+                            'DHCP Helper Address': '',
+                            'Proxy ARP': ''
+                        }
+                    rows.append(row)
+            
+            # Update column widths
+            for row in rows:
+                for key, value in row.items():
+                    col_widths[key] = max(col_widths[key], len(str(value)))
+        
+        # Build table output
+        table_lines = []
+        
+        # Create separator line
+        separator = '-' * (sum(col_widths.values()) + 3 * (len(headers) - 1))
+        
+        # Header
+        header_line = '   '.join([header.ljust(col_widths[header]) for header in headers])
+        table_lines.append(header_line)
+        table_lines.append(separator)
+        
+        # Data rows
+        for row in rows:
+            data_line = '   '.join([str(row[header]).ljust(col_widths[header]) for header in headers])
+            table_lines.append(data_line)
+        
+        return '\n'.join(table_lines)

--- a/show_gnmi_util/formatter/show_vlan_brief_formatter.py
+++ b/show_gnmi_util/formatter/show_vlan_brief_formatter.py
@@ -3,6 +3,8 @@ Formatter for 'show vlan brief' command
 """
 
 from typing import Dict, Any, List
+from tabulate import tabulate
+from natsort import natsorted
 from ..common.base_formatter import BaseFormatter
 
 
@@ -34,7 +36,7 @@ class ShowVlanBriefFormatter(BaseFormatter):
     
     def _build_vlan_table(self, vlan_data: Dict[str, Any]) -> str:
         """
-        Build VLAN table from JSON data
+        Build VLAN table from JSON data using tabulate
         
         Args:
             vlan_data: Dictionary with VLAN information
@@ -45,36 +47,32 @@ class ShowVlanBriefFormatter(BaseFormatter):
         # Define headers
         headers = ['VLAN', 'IP Address', 'Ports', 'Port Tagging', 'DHCP Helper Address', 'Proxy ARP']
         
-        # Calculate column widths
-        col_widths = {
-            'VLAN': len('VLAN'),
-            'IP Address': len('IP Address'),
-            'Ports': len('Ports'),
-            'Port Tagging': len('Port Tagging'),
-            'DHCP Helper Address': len('DHCP Helper Address'),
-            'Proxy ARP': len('Proxy ARP')
-        }
-        
         # Prepare rows
-        rows = []
-        for vlan_name, vlan_info in sorted(vlan_data.items()):
+        table_data = []
+        
+        # Use natsorted for natural sorting (Vlan1, Vlan2, Vlan10, Vlan20, etc.)
+        for vlan_name in natsorted(vlan_data.keys()):
+            vlan_info = vlan_data[vlan_name]
             vlan_id = vlan_info.get('vlan_id', '')
             ip_addresses = vlan_info.get('ip_address', [])
             ports_list = vlan_info.get('ports', [])
             dhcp_helpers = vlan_info.get('dhcp_helper_addresses', [])
             proxy_arp = vlan_info.get('proxy_arp', 'disabled')
             
+            # Format IP addresses and DHCP helpers
+            ip_addr_str = ', '.join(ip_addresses) if ip_addresses else ''
+            dhcp_helper_str = ', '.join(dhcp_helpers) if dhcp_helpers else ''
+            
             # Handle multiple ports - create separate rows for each port
             if not ports_list:
-                row = {
-                    'VLAN': vlan_id,
-                    'IP Address': ', '.join(ip_addresses) if ip_addresses else '',
-                    'Ports': '',
-                    'Port Tagging': '',
-                    'DHCP Helper Address': ', '.join(dhcp_helpers) if dhcp_helpers else '',
-                    'Proxy ARP': proxy_arp
-                }
-                rows.append(row)
+                table_data.append([
+                    vlan_id,
+                    ip_addr_str,
+                    '',
+                    '',
+                    dhcp_helper_str,
+                    proxy_arp
+                ])
             else:
                 for idx, port_info in enumerate(ports_list):
                     port_name = port_info.get('name', '')
@@ -82,45 +80,24 @@ class ShowVlanBriefFormatter(BaseFormatter):
                     
                     if idx == 0:
                         # First row shows VLAN ID and all info
-                        row = {
-                            'VLAN': vlan_id,
-                            'IP Address': ', '.join(ip_addresses) if ip_addresses else '',
-                            'Ports': port_name,
-                            'Port Tagging': port_tagging,
-                            'DHCP Helper Address': ', '.join(dhcp_helpers) if dhcp_helpers else '',
-                            'Proxy ARP': proxy_arp
-                        }
+                        table_data.append([
+                            vlan_id,
+                            ip_addr_str,
+                            port_name,
+                            port_tagging,
+                            dhcp_helper_str,
+                            proxy_arp
+                        ])
                     else:
                         # Subsequent rows only show port info
-                        row = {
-                            'VLAN': '',
-                            'IP Address': '',
-                            'Ports': port_name,
-                            'Port Tagging': port_tagging,
-                            'DHCP Helper Address': '',
-                            'Proxy ARP': ''
-                        }
-                    rows.append(row)
-            
-            # Update column widths
-            for row in rows:
-                for key, value in row.items():
-                    col_widths[key] = max(col_widths[key], len(str(value)))
+                        table_data.append([
+                            '',
+                            '',
+                            port_name,
+                            port_tagging,
+                            '',
+                            ''
+                        ])
         
-        # Build table output
-        table_lines = []
-        
-        # Create separator line
-        separator = '-' * (sum(col_widths.values()) + 3 * (len(headers) - 1))
-        
-        # Header
-        header_line = '   '.join([header.ljust(col_widths[header]) for header in headers])
-        table_lines.append(header_line)
-        table_lines.append(separator)
-        
-        # Data rows
-        for row in rows:
-            data_line = '   '.join([str(row[header]).ljust(col_widths[header]) for header in headers])
-            table_lines.append(data_line)
-        
-        return '\n'.join(table_lines)
+        # Use tabulate with 'simple' format (includes separator line)
+        return tabulate(table_data, headers=headers, tablefmt='simple', stralign='left')

--- a/show_gnmi_util/scripts/show_arm_cli.py
+++ b/show_gnmi_util/scripts/show_arm_cli.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 """
 CLI tool to read JSON files and convert them to tabular format
 """
@@ -13,7 +13,7 @@ script_dir = Path(__file__).parent
 parent_dir = script_dir.parent.parent
 sys.path.insert(0, str(parent_dir))
 
-from show_gnmi_util.formatter import ShowVersionFormatter, ShowVlanBriefFormatter
+from show_gnmi_util.formatter import ShowVersionFormatter, ShowVlanBriefFormatter, ShowRebootCauseFormatter, ShowRebootCauseHistoryFormatter
 
 
 def read_json_file(filepath: str) -> dict:
@@ -67,6 +67,36 @@ def format_show_vlan_brief(json_file: str) -> str:
     return formatter.format(json_data)
 
 
+def format_show_reboot_cause(json_file: str) -> str:
+    """
+    Format show reboot cause JSON to tabular format
+    
+    Args:
+        json_file: Path to reboot cause JSON file
+        
+    Returns:
+        Formatted tabular output
+    """
+    json_data = read_json_file(json_file)
+    formatter = ShowRebootCauseFormatter()
+    return formatter.format(json_data)
+
+
+def format_show_reboot_cause_history(json_file: str) -> str:
+    """
+    Format show reboot cause history JSON to tabular format
+    
+    Args:
+        json_file: Path to reboot cause history JSON file
+        
+    Returns:
+        Formatted tabular output
+    """
+    json_data = read_json_file(json_file)
+    formatter = ShowRebootCauseHistoryFormatter()
+    return formatter.format(json_data)
+
+
 def main():
     """
     Main function to demonstrate formatters
@@ -76,6 +106,8 @@ def main():
     # File paths
     version_json = script_dir / "show_version_sample.json"
     vlan_json = script_dir / "show_vlan_brief_sample.json"
+    reboot_cause_json = script_dir / "show_reboot_cause_sample.json"
+    reboot_cause_history_json = script_dir / "show_reboot_cause_history_sample.json"
     
     # Format and display show version
     print("=" * 80)
@@ -93,12 +125,31 @@ def main():
     print(vlan_output)
     print()
     
-    # Return both outputs for programmatic use
+    # Format and display show reboot cause
+    print("=" * 80)
+    print("SHOW REBOOT CAUSE")
+    print("=" * 80)
+    reboot_cause_output = format_show_reboot_cause(str(reboot_cause_json))
+    print(reboot_cause_output)
+    print()
+    
+    # Format and display show reboot cause history
+    print("=" * 80)
+    print("SHOW REBOOT CAUSE HISTORY")
+    print("=" * 80)
+    reboot_cause_history_output = format_show_reboot_cause_history(str(reboot_cause_history_json))
+    print(reboot_cause_history_output)
+    print()
+    
+    # Return all outputs for programmatic use
     return {
         'show_version': version_output,
-        'show_vlan_brief': vlan_output
+        'show_vlan_brief': vlan_output,
+        'show_reboot_cause': reboot_cause_output,
+        'show_reboot_cause_history': reboot_cause_history_output
     }
 
 
 if __name__ == "__main__":
     main()
+

--- a/show_gnmi_util/scripts/show_arm_cli.py
+++ b/show_gnmi_util/scripts/show_arm_cli.py
@@ -1,0 +1,104 @@
+﻿#!/usr/bin/env python3
+"""
+CLI tool to read JSON files and convert them to tabular format
+"""
+
+import json
+import sys
+import os
+from pathlib import Path
+
+# Add parent directory to path for imports
+script_dir = Path(__file__).parent
+parent_dir = script_dir.parent.parent
+sys.path.insert(0, str(parent_dir))
+
+from show_gnmi_util.formatter import ShowVersionFormatter, ShowVlanBriefFormatter
+
+
+def read_json_file(filepath: str) -> dict:
+    """
+    Read and parse JSON file
+    
+    Args:
+        filepath: Path to JSON file
+        
+    Returns:
+        Parsed JSON data as dictionary
+    """
+    try:
+        with open(filepath, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Error: File '{filepath}' not found", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error: Invalid JSON in '{filepath}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def format_show_version(json_file: str) -> str:
+    """
+    Format show version JSON to tabular format
+    
+    Args:
+        json_file: Path to show version JSON file
+        
+    Returns:
+        Formatted tabular output
+    """
+    json_data = read_json_file(json_file)
+    formatter = ShowVersionFormatter()
+    return formatter.format(json_data)
+
+
+def format_show_vlan_brief(json_file: str) -> str:
+    """
+    Format show vlan brief JSON to tabular format
+    
+    Args:
+        json_file: Path to show vlan brief JSON file
+        
+    Returns:
+        Formatted tabular output
+    """
+    json_data = read_json_file(json_file)
+    formatter = ShowVlanBriefFormatter()
+    return formatter.format(json_data)
+
+
+def main():
+    """
+    Main function to demonstrate formatters
+    """
+    script_dir = Path(__file__).parent
+    
+    # File paths
+    version_json = script_dir / "show_version_sample.json"
+    vlan_json = script_dir / "show_vlan_brief_sample.json"
+    
+    # Format and display show version
+    print("=" * 80)
+    print("SHOW VERSION")
+    print("=" * 80)
+    version_output = format_show_version(str(version_json))
+    print(version_output)
+    print()
+    
+    # Format and display show vlan brief
+    print("=" * 80)
+    print("SHOW VLAN BRIEF")
+    print("=" * 80)
+    vlan_output = format_show_vlan_brief(str(vlan_json))
+    print(vlan_output)
+    print()
+    
+    # Return both outputs for programmatic use
+    return {
+        'show_version': version_output,
+        'show_vlan_brief': vlan_output
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/show_gnmi_util/scripts/show_reboot_cause_history_sample.json
+++ b/show_gnmi_util/scripts/show_reboot_cause_history_sample.json
@@ -1,0 +1,32 @@
+{
+  "2025_07_07_02_35_26": {
+    "cause": "reboot",
+    "comment": "N/A",
+    "time": "Mon Jul  7 02:34:07 AM UTC 2025",
+    "user": "admin"
+  },
+  "2025_07_07_02_43_43": {
+    "cause": "reboot",
+    "comment": "N/A",
+    "time": "Mon Jul  7 02:42:22 AM UTC 2025",
+    "user": "admin"
+  },
+  "2025_07_08_09_21_21": {
+    "cause": "reboot",
+    "comment": "N/A",
+    "time": "Tue Jul  8 09:20:13 AM UTC 2025",
+    "user": ""
+  },
+  "2025_07_08_11_53_50": {
+    "cause": "Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)",
+    "comment": "Unknown",
+    "time": "N/A",
+    "user": "N/A"
+  },
+  "2025_07_08_18_29_38": {
+    "cause": "reboot",
+    "comment": "N/A",
+    "time": "Tue Jul  8 06:28:26 PM UTC 2025",
+    "user": "admin"
+  }
+}

--- a/show_gnmi_util/scripts/show_reboot_cause_sample.json
+++ b/show_gnmi_util/scripts/show_reboot_cause_sample.json
@@ -1,0 +1,7 @@
+{
+  "gen_time": "2025_07_08_18_29_38",
+  "cause": "reboot",
+  "user": "admin", 
+  "time": "Tue Jul  8 06:28:26 PM UTC 2025",
+  "comment": "N/A"
+}

--- a/show_gnmi_util/scripts/show_version_sample.json
+++ b/show_gnmi_util/scripts/show_version_sample.json
@@ -1,0 +1,44 @@
+﻿{
+  "sonic_software_version": "SONiC.test_branch.1-a8fbac59d",
+  "sonic_os_version": "\u003cnil\u003e",
+  "distribution": "Debian 11.4",
+  "kernel": "5.10.0-18-2-amd64",
+  "build_commit": "a8fbac59d",
+  "build_date": "\u003cnil\u003e",
+  "built_by": "\u003cnil\u003e",
+  "platform": "test_onie_platform",
+  "hwsku": "",
+  "asic": "mellanox",
+  "asic_count": "1",
+  "serial_number": "N/A",
+  "model_number": "N/A",
+  "hardware_revision": "N/A",
+  "uptime": "07:42:51 up 16 days, 14:51,  2 users,  load average: 0.00, 0.00, 0.00",
+  "date": "Fri 18 Jul 2025 18:00:00",
+  "docker_images": [
+    {
+        "Repository": "docker-mux",
+        "Tag": "20250510.14",
+        "ID": "sha256:372601148371578e886d545864469deca0ad8db5618e10ae6124429637f86a02",
+        "Size": "366MB"
+    },
+    {
+        "Repository": "docker-mux",
+        "Tag": "latest",
+        "ID": "sha256:372601148371578e886d545864469deca0ad8db5618e10ae6124429637f86a02",
+        "Size": "366MB"
+    },
+    {
+        "Repository": "docker-database",
+        "Tag": "20250510.14",
+        "ID": "sha256:ea4d44010ec1ca9a5129842aebe5a36d177c51a585c4c54e83bd6c4325492af9",
+        "Size": "321MB"
+    },
+    {
+        "Repository": "docker-database",
+        "Tag": "latest",
+        "ID": "sha256:ea4d44010ec1ca9a5129842aebe5a36d177c51a585c4c54e83bd6c4325492af9",
+        "Size": "321MB"
+    }
+  ]
+}

--- a/show_gnmi_util/scripts/show_vlan_brief_sample.json
+++ b/show_gnmi_util/scripts/show_vlan_brief_sample.json
@@ -1,0 +1,14 @@
+﻿{
+  "Vlan1": {
+    "dhcp_helper_addresses": ["192.0.0.1"],
+    "ip_address": ["192.168.0.1/21"],
+    "ports": [
+      {
+        "name": "Ethernet120",
+        "port_tagging": "untagged"
+      }
+    ],
+    "proxy_arp": "disabled",
+    "vlan_id": "1"
+  }
+}

--- a/show_gnmi_util/test/__init__.py
+++ b/show_gnmi_util/test/__init__.py
@@ -1,0 +1,3 @@
+﻿"""
+Test package for formatters
+"""

--- a/show_gnmi_util/test/test_formatters.py
+++ b/show_gnmi_util/test/test_formatters.py
@@ -1,0 +1,113 @@
+﻿"""
+Unit tests for formatters
+"""
+
+import unittest
+import json
+from pathlib import Path
+import sys
+
+# Add parent directory to path
+test_dir = Path(__file__).parent
+parent_dir = test_dir.parent.parent
+sys.path.insert(0, str(parent_dir))
+
+from show_gnmi_util.formatter import ShowVersionFormatter, ShowVlanBriefFormatter
+
+
+class TestShowVersionFormatter(unittest.TestCase):
+    """Test cases for ShowVersionFormatter"""
+    
+    def setUp(self):
+        self.formatter = ShowVersionFormatter()
+        self.sample_data = {
+            "sonic_software_version": "SONiC.test_branch.1-a8fbac59d",
+            "sonic_os_version": "<nil>",
+            "distribution": "Debian 11.4",
+            "kernel": "5.10.0-18-2-amd64",
+            "build_commit": "a8fbac59d",
+            "platform": "test_platform",
+            "asic": "mellanox",
+            "asic_count": "1"
+        }
+    
+    def test_format_basic(self):
+        """Test basic formatting"""
+        output = self.formatter.format(self.sample_data)
+        self.assertIn("SONiC Software Version", output)
+        self.assertIn("SONiC.test_branch.1-a8fbac59d", output)
+        self.assertIn("Debian 11.4", output)
+    
+    def test_format_with_docker_images(self):
+        """Test formatting with docker images"""
+        data = self.sample_data.copy()
+        data['docker_images'] = [
+            {
+                "Repository": "docker-test",
+                "Tag": "latest",
+                "ID": "sha256:1234567890ab",
+                "Size": "100MB"
+            }
+        ]
+        output = self.formatter.format(data)
+        self.assertIn("Docker images:", output)
+        self.assertIn("docker-test", output)
+    
+    def test_nil_values(self):
+        """Test handling of nil values"""
+        output = self.formatter.format(self.sample_data)
+        # Should not show <nil> in output
+        self.assertNotIn("<nil>", output)
+
+
+class TestShowVlanBriefFormatter(unittest.TestCase):
+    """Test cases for ShowVlanBriefFormatter"""
+    
+    def setUp(self):
+        self.formatter = ShowVlanBriefFormatter()
+        self.sample_data = {
+            "Vlan1": {
+                "dhcp_helper_addresses": ["192.0.0.1"],
+                "ip_address": ["192.168.0.1/21"],
+                "ports": [
+                    {
+                        "name": "Ethernet120",
+                        "port_tagging": "untagged"
+                    }
+                ],
+                "proxy_arp": "disabled",
+                "vlan_id": "1"
+            }
+        }
+    
+    def test_format_basic(self):
+        """Test basic VLAN formatting"""
+        output = self.formatter.format(self.sample_data)
+        self.assertIn("VLAN", output)
+        self.assertIn("Ethernet120", output)
+        self.assertIn("untagged", output)
+    
+    def test_empty_data(self):
+        """Test formatting with empty data"""
+        output = self.formatter.format({})
+        self.assertIn("No VLANs configured", output)
+    
+    def test_multiple_ports(self):
+        """Test formatting with multiple ports"""
+        data = {
+            "Vlan2": {
+                "vlan_id": "2",
+                "ports": [
+                    {"name": "Ethernet0", "port_tagging": "tagged"},
+                    {"name": "Ethernet4", "port_tagging": "untagged"}
+                ],
+                "proxy_arp": "enabled"
+            }
+        }
+        output = self.formatter.format(data)
+        self.assertIn("Ethernet0", output)
+        self.assertIn("Ethernet4", output)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/show_gnmi_util/test/test_formatters.py
+++ b/show_gnmi_util/test/test_formatters.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Unit tests for formatters
 """
 
@@ -12,7 +12,7 @@ test_dir = Path(__file__).parent
 parent_dir = test_dir.parent.parent
 sys.path.insert(0, str(parent_dir))
 
-from show_gnmi_util.formatter import ShowVersionFormatter, ShowVlanBriefFormatter
+from show_gnmi_util.formatter import ShowVersionFormatter, ShowVlanBriefFormatter, ShowRebootCauseFormatter, ShowRebootCauseHistoryFormatter
 
 
 class TestShowVersionFormatter(unittest.TestCase):
@@ -109,5 +109,129 @@ class TestShowVlanBriefFormatter(unittest.TestCase):
         self.assertIn("Ethernet4", output)
 
 
+class TestShowRebootCauseFormatter(unittest.TestCase):
+    """Test cases for ShowRebootCauseFormatter"""
+    
+    def setUp(self):
+        self.formatter = ShowRebootCauseFormatter()
+        self.sample_data = {
+            "gen_time": "2025_07_08_18_29_38",
+            "cause": "reboot",
+            "user": "admin",
+            "time": "Tue Jul  8 06:28:26 PM UTC 2025",
+            "comment": "N/A"
+        }
+    
+    def test_format_basic(self):
+        """Test basic reboot cause formatting"""
+        output = self.formatter.format(self.sample_data)
+        self.assertIn("Previous reboot cause:", output)
+        self.assertIn("Generation Time", output)
+        self.assertIn("2025_07_08_18_29_38", output)
+        self.assertIn("Cause", output)
+        self.assertIn("reboot", output)
+        self.assertIn("User", output)
+        self.assertIn("admin", output)
+    
+    def test_format_with_na_values(self):
+        """Test formatting with N/A values"""
+        data = {
+            "gen_time": "2025_07_08_11_53_50",
+            "cause": "Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)",
+            "user": "N/A",
+            "time": "N/A",
+            "comment": "Unknown"
+        }
+        output = self.formatter.format(data)
+        self.assertIn("Hardware - Other", output)
+        self.assertIn("User: N/A", output)
+        self.assertIn("Time: N/A", output)
+    
+    def test_empty_data(self):
+        """Test formatting with empty data"""
+        output = self.formatter.format({})
+        self.assertIn("No reboot cause information available", output)
+    
+    def test_missing_fields(self):
+        """Test formatting with missing fields"""
+        data = {"cause": "power-on"}
+        output = self.formatter.format(data)
+        self.assertIn("Cause: power-on", output)
+        self.assertIn("User: N/A", output)
+        self.assertIn("Time: N/A", output)
+
+
+class TestShowRebootCauseHistoryFormatter(unittest.TestCase):
+    """Test cases for ShowRebootCauseHistoryFormatter"""
+    
+    def setUp(self):
+        self.formatter = ShowRebootCauseHistoryFormatter()
+        self.sample_data = {
+            "2025_07_07_02_35_26": {
+                "cause": "reboot",
+                "comment": "N/A",
+                "time": "Mon Jul  7 02:34:07 AM UTC 2025",
+                "user": "admin"
+            },
+            "2025_07_08_09_21_21": {
+                "cause": "reboot",
+                "comment": "N/A",
+                "time": "Tue Jul  8 09:20:13 AM UTC 2025",
+                "user": ""
+            },
+            "2025_07_08_11_53_50": {
+                "cause": "Hardware - Other (gpi-2, description: gpi 2 detailed fault, time: 2025-07-08 11:53:04)",
+                "comment": "Unknown",
+                "time": "N/A",
+                "user": "N/A"
+            }
+        }
+    
+    def test_format_basic(self):
+        """Test basic reboot cause history formatting"""
+        output = self.formatter.format(self.sample_data)
+        self.assertIn("Name", output)
+        self.assertIn("Cause", output)
+        self.assertIn("Time", output)
+        self.assertIn("User", output)
+        self.assertIn("Comment", output)
+        self.assertIn("2025_07_07_02_35_26", output)
+        self.assertIn("admin", output)
+    
+    def test_format_with_hardware_fault(self):
+        """Test formatting with complex hardware fault description"""
+        output = self.formatter.format(self.sample_data)
+        self.assertIn("Hardware - Other", output)
+        self.assertIn("gpi-2", output)
+        self.assertIn("Unknown", output)
+    
+    def test_format_with_empty_user(self):
+        """Test formatting with empty user field"""
+        output = self.formatter.format(self.sample_data)
+        # Should show N/A for empty user field
+        self.assertIn("N/A", output)
+    
+    def test_empty_data(self):
+        """Test formatting with empty data"""
+        output = self.formatter.format({})
+        self.assertIn("No reboot cause history available", output)
+    
+    def test_single_entry(self):
+        """Test formatting with single entry"""
+        data = {
+            "2025_07_08_18_29_38": {
+                "cause": "reboot",
+                "comment": "N/A",
+                "time": "Tue Jul  8 06:28:26 PM UTC 2025",
+                "user": "admin"
+            }
+        }
+        output = self.formatter.format(data)
+        self.assertIn("2025_07_08_18_29_38", output)
+        self.assertIn("reboot", output)
+        self.assertIn("admin", output)
+
+
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Added json to tabular formatter for show reboot cause and show reboot cause history.

#### How I did it

Added classes ShowRebootCauseFormatter and ShowRebootCauseHistoryFormatter in show_reboot_cause_formatter.py wherein format() takes json output of gNMI and converts to readable tabular form.

Added UTs.

#### How to verify it

meghnamishra@meghnamishra-dev-vm:~/sonic-utilities.msft$ python3 -m unittest show_gnmi_util.test.test_formatters -v
test_empty_data (show_gnmi_util.test.test_formatters.TestShowRebootCauseFormatter)
Test formatting with empty data ... ok
test_format_basic (show_gnmi_util.test.test_formatters.TestShowRebootCauseFormatter)
Test basic reboot cause formatting ... ok
test_format_with_na_values (show_gnmi_util.test.test_formatters.TestShowRebootCauseFormatter)
Test formatting with N/A values ... ok
test_missing_fields (show_gnmi_util.test.test_formatters.TestShowRebootCauseFormatter)
Test formatting with missing fields ... ok
test_empty_data (show_gnmi_util.test.test_formatters.TestShowRebootCauseHistoryFormatter)
Test formatting with empty data ... ok
test_format_basic (show_gnmi_util.test.test_formatters.TestShowRebootCauseHistoryFormatter)
Test basic reboot cause history formatting ... ok
test_format_with_empty_user (show_gnmi_util.test.test_formatters.TestShowRebootCauseHistoryFormatter)
Test formatting with empty user field ... ok
test_format_with_hardware_fault (show_gnmi_util.test.test_formatters.TestShowRebootCauseHistoryFormatter)
Test formatting with complex hardware fault description ... ok
test_single_entry (show_gnmi_util.test.test_formatters.TestShowRebootCauseHistoryFormatter)
Test formatting with single entry ... ok
test_format_basic (show_gnmi_util.test.test_formatters.TestShowVersionFormatter)
Test basic formatting ... ok
test_format_with_docker_images (show_gnmi_util.test.test_formatters.TestShowVersionFormatter)
Test formatting with docker images ... ok
test_nil_values (show_gnmi_util.test.test_formatters.TestShowVersionFormatter)
Test handling of nil values ... ok
test_empty_data (show_gnmi_util.test.test_formatters.TestShowVlanBriefFormatter)
Test formatting with empty data ... ok
test_format_basic (show_gnmi_util.test.test_formatters.TestShowVlanBriefFormatter)
Test basic VLAN formatting ... ok
test_multiple_ports (show_gnmi_util.test.test_formatters.TestShowVlanBriefFormatter)
Test formatting with multiple ports ... ok

----------------------------------------------------------------------
Ran 15 tests in 0.002s

OK

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

