### PR TITLE
Fix crash in dump port state command on multi-ASIC systems

### DIFF
--- a/dump/match_infra.py
+++ b/dump/match_infra.py
@@ -6,6 +6,7 @@ from dump.helper import verbose_print
 from swsscommon.swsscommon import SonicV2Connector, SonicDBConfig
 from sonic_py_common import multi_asic
 from utilities_common.constants import DEFAULT_NAMESPACE
+from utilities_common.general import load_db_config
 
 # Constants
 CONN = "conn"
@@ -242,11 +243,7 @@ class ConnectionPool:
         self.cache = dict()  # Pool of SonicV2Connector objects
 
     def initialize_connector(self, ns):
-        if multi_asic.is_multi_asic():
-            if not SonicDBConfig.isGlobalInit():
-                SonicDBConfig.load_sonic_global_db_config()
-        elif not SonicDBConfig.isInit():
-            SonicDBConfig.load_sonic_db_config()
+        load_db_config()
         return SonicV2Connector(namespace=ns, use_unix_socket_path=True)
 
     def get(self, db_name, ns, update=False):

--- a/dump/match_infra.py
+++ b/dump/match_infra.py
@@ -242,18 +242,20 @@ class ConnectionPool:
         self.cache = dict()  # Pool of SonicV2Connector objects
 
     def initialize_connector(self, ns):
-        if not SonicDBConfig.isInit():
-            if multi_asic.is_multi_asic():
+        if multi_asic.is_multi_asic():
+            if not SonicDBConfig.isGlobalInit():
                 SonicDBConfig.load_sonic_global_db_config()
-            else:
-                SonicDBConfig.load_sonic_db_config()
+        elif not SonicDBConfig.isInit():
+            SonicDBConfig.load_sonic_db_config()
         return SonicV2Connector(namespace=ns, use_unix_socket_path=True)
 
     def get(self, db_name, ns, update=False):
         """ Returns a SonicV2Connector Object and caches it for further requests """
         if ns not in self.cache:
             self.cache[ns] = {}
+        if CONN not in self.cache[ns]:
             self.cache[ns][CONN] = self.initialize_connector(ns)
+        if CONN_TO not in self.cache[ns]:
             self.cache[ns][CONN_TO] = set()
         if update or db_name not in self.cache[ns][CONN_TO]:
             self.cache[ns][CONN].connect(db_name)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Currently `sudo dump state -d APPL_DB -n asic0 port Ethernet16` CLI command crashes on multi-asic platforms. There are couple of fixes required described below : 

Currently, the connection pool cache was being partially initialized, where a namespace dictionary was created but the nested connection keys were accessed without checking if they existed first caused crash due to KeyError.  This change 9cd6c8d fixes these conditional checks, but it is not backported to 202405. Hence, we miss out on fix in that change to ensure CONN and CONN_TO keys are initialized before accessing them in the cache in 202405.

Additionally, in initialize_connector(), the condition checks if any database configuration is loaded, but multi-ASIC systems specifically need the global database configuration to be loaded. The multi-ASIC platforms specifically needs the global database configuration to be initialized. This pull request fixes the bug in connection pool cache and fixes the condition on loading expected database configuration based on single or multi-asic system. I have opened [PR4229](https://github.com/sonic-net/sonic-utilities/pull/4229) fixes this particular issue on master.

 
#### How I did it

- Fixed the connection pool cache issue by backporting the needed conditional fix in get function from 9cd6c8d 
- Corrected the database configuration initialization by using load_db_config helper function to ensure the correct DB configuration is loaded.

#### How to verify it

Verified running the command on chassis with a multi-asic linecard. After fix, dump port state command no longer result in a crash and returns the expected results.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

