### PR TITLE
feat: support namespace arg for show bfd (#3885)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ dist/
 coverage.xml
 htmlcov/
 
+# Dev tools
+.vscode/
+.idea/
+
 # Ignores for sonic-utilities-data
 sonic-utilities-data/debian/*
 !sonic-utilities-data/debian/changelog

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -2211,7 +2211,7 @@ This command displays the state and key parameters of all BFD sessions.
 
 - Usage:
   ```
-  show bfd summary
+  show bfd summary [-n <namespace>]
   ```
 - Example:
   ```
@@ -2230,7 +2230,7 @@ This command displays the state and key parameters of all BFD sessions that matc
 
 - Usage:
   ```
-  show bfd peer <peer-ip>
+  show bfd peer <peer-ip> [-n <namespace>]
   ```
 - Example:
   ```

--- a/show/main.py
+++ b/show/main.py
@@ -2252,12 +2252,17 @@ def bfd():
 # 'summary' subcommand ("show bfd summary")
 @bfd.command()
 @clicommon.pass_db
-def summary(db):
+@click.option('--namespace', '-n', 'namespace', default=None, type=str, show_default=True,
+              help='Namespace name or all', callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def summary(db, namespace):
     """Show bfd session information"""
     bfd_headers = ["Peer Addr", "Interface", "Vrf", "State", "Type", "Local Addr",
                 "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
 
-    bfd_keys = db.db.keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*")
+    if namespace is None:
+        namespace = constants.DEFAULT_NAMESPACE
+
+    bfd_keys = db.db_clients[namespace].keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*")
 
     click.echo("Total number of BFD sessions: {}".format(0 if bfd_keys is None else len(bfd_keys)))
 
@@ -2265,7 +2270,7 @@ def summary(db):
     if bfd_keys is not None:
         for key in bfd_keys:
             key_values = key.split('|')
-            values = db.db.get_all(db.db.STATE_DB, key)
+            values = db.db_clients[namespace].get_all(db.db.STATE_DB, key)
             if "local_discriminator" not in values.keys():
                 values["local_discriminator"] = "NA"
             bfd_body.append([key_values[3], key_values[2], key_values[1], values["state"], values["type"], values["local_addr"],
@@ -2278,13 +2283,18 @@ def summary(db):
 @bfd.command()
 @clicommon.pass_db
 @click.argument('peer_ip', required=True)
-def peer(db, peer_ip):
+@click.option('--namespace', '-n', 'namespace', default=None, type=str, show_default=True,
+              help='Namespace name or all', callback=multi_asic_util.multi_asic_namespace_validation_callback)
+def peer(db, peer_ip, namespace):
     """Show bfd session information for BFD peer"""
     bfd_headers = ["Peer Addr", "Interface", "Vrf", "State", "Type", "Local Addr",
                 "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
 
-    bfd_keys = db.db.keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*|{}".format(peer_ip))
-    delimiter = db.db.get_db_separator(db.db.STATE_DB)
+    if namespace is None:
+        namespace = constants.DEFAULT_NAMESPACE
+
+    bfd_keys = db.db_clients[namespace].keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*|{}".format(peer_ip))
+    delimiter = db.db_clients[namespace].get_db_separator(db.db.STATE_DB)
 
     if bfd_keys is None or len(bfd_keys) == 0:
         click.echo("No BFD sessions found for peer IP {}".format(peer_ip))
@@ -2296,7 +2306,7 @@ def peer(db, peer_ip):
     if bfd_keys is not None:
         for key in bfd_keys:
             key_values = key.split(delimiter)
-            values = db.db.get_all(db.db.STATE_DB, key)
+            values = db.db_clients[namespace].get_all(db.db.STATE_DB, key)
             if "local_discriminator" not in values.keys():
                 values["local_discriminator"] = "NA"
             bfd_body.append([key_values[3], key_values[2], key_values[1], values.get("state"), values.get("type"), values.get("local_addr"),

--- a/tests/bfd_input/bfd_masic_test_vectors.py
+++ b/tests/bfd_input/bfd_masic_test_vectors.py
@@ -1,0 +1,30 @@
+expected_show_bfd_summary_output = """\
+Total number of BFD sessions: 4
+Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
+-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
+10.0.1.1     default      default  DOWN     async_active  10.0.0.1                300            500             3  true        NA
+10.0.2.1     Ethernet12   default  UP       async_active  10.0.0.1                200            600             3  false       88
+2000::10:1   default      default  UP       async_active  2000::1                 100            700             3  false       NA
+10.0.1.1     default      VrfRed   UP       async_active  10.0.0.1                400            500             5  false       NA
+"""  # noqa: E501
+
+expected_show_bfd_peer_output = """\
+Total number of BFD sessions for peer IP 10.0.1.1: 2
+Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
+-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
+10.0.1.1     default      default  DOWN     async_active  10.0.0.1                300            500             3  true        NA
+10.0.1.1     default      VrfRed   UP       async_active  10.0.0.1                400            500             5  false       NA
+"""  # noqa: E501
+
+test_data = {
+    "show_bfd_summary_masic_asic0": {
+        "cmd": "summary",
+        "args": ["-n", "asic0"],
+        "expected_output": expected_show_bfd_summary_output,
+    },
+    "show_bfd_peer_masic_asic0": {
+        "cmd": "peer",
+        "args": ["10.0.1.1", "-n", "asic0"],
+        "expected_output": expected_show_bfd_peer_output,
+    },
+}

--- a/tests/mock_tables/asic0/state_db.json
+++ b/tests/mock_tables/asic0/state_db.json
@@ -339,5 +339,42 @@
     },
     "PORT_CAPACITY_TABLE|PORT_CAPACITY_DATA" : {
         "capacity": "80000"
+    },
+    "BFD_SESSION_TABLE|default|default|10.0.1.1": {
+        "state": "DOWN",
+        "type": "async_active",
+        "local_addr" : "10.0.0.1",
+        "tx_interval" :"300",
+        "rx_interval" : "500",
+        "multiplier" : "3",
+        "multihop": "true"
+    },
+    "BFD_SESSION_TABLE|default|Ethernet12|10.0.2.1": {
+        "state": "UP",
+        "type": "async_active",
+        "local_addr" : "10.0.0.1",
+        "tx_interval" :"200",
+        "rx_interval" : "600",
+        "multiplier" : "3",
+        "multihop": "false",
+        "local_discriminator": "88"
+    },
+    "BFD_SESSION_TABLE|default|default|2000::10:1": {
+        "state": "UP",
+        "type": "async_active",
+        "local_addr" : "2000::1",
+        "tx_interval" :"100",
+        "rx_interval" : "700",
+        "multiplier" : "3",
+        "multihop": "false"
+    },
+    "BFD_SESSION_TABLE|VrfRed|default|10.0.1.1": {
+        "state": "UP",
+        "type": "async_active",
+        "local_addr" : "10.0.0.1",
+        "tx_interval" :"400",
+        "rx_interval" : "500",
+        "multiplier" : "5",
+        "multihop": "false"
     }
 }

--- a/tests/multi_asic_show_bfd_test.py
+++ b/tests/multi_asic_show_bfd_test.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from importlib import reload
+
+from click.testing import CliRunner
+
+import show.main as show
+from tests.bfd_input.bfd_masic_test_vectors import test_data
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+sys.path.insert(0, test_path)
+sys.path.insert(0, modules_path)
+
+
+class TestShowBfdMultiAsic(object):
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+
+        # Set the database to mock multi-asic state
+        from mock_tables import mock_multi_asic
+        reload(mock_multi_asic)
+        from mock_tables import dbconnector
+        dbconnector.load_namespace_config()
+
+    def test_show_bfd_summary_masic_asic0(self):
+        self.command_executor(test_data["show_bfd_summary_masic_asic0"])
+
+    def test_show_bfd_peer_masic_asic0(self):
+        self.command_executor(test_data["show_bfd_peer_masic_asic0"])
+
+    @classmethod
+    def teardown_class(cls):
+        # Reset the database to mock single-asic state
+        from mock_tables import mock_single_asic
+        reload(mock_single_asic)
+        from mock_tables import dbconnector
+        dbconnector.load_database_config()
+
+        os.environ["PATH"] = os.pathsep.join(os.environ["PATH"].split(os.pathsep)[:-1])
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+
+        print("TEARDOWN")
+
+    @staticmethod
+    def command_executor(test_case_data):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["bfd"].commands[test_case_data["cmd"]], args=test_case_data["args"])
+        print("result.exit_code: {}".format(result.exit_code))
+        print("result.output: {}".format(result.output))
+        assert result.exit_code == 0
+        assert result.output == test_case_data["expected_output"]


### PR DESCRIPTION
What I did
Added the namespace support for show bfd summary & show bfd peer <peer_id> command. For example, users can run show bfd summary -n asic0, show bfd peer 10.0.1.1 -n asic0 and etc.

How I did it
How to verify it
Run show bfd summary -n <namespace> and show bfd peer <peer_id> -n <namespace> and verify the output

Previous command output (if the output of a command-line utility has changed) Nothing has changed to the output of these 2 commands, we are only adding the namespace argument support in this PR. Users can still use the sudo ip netns exec asicX  ... way after this PR.

I confirmed the output of sudo ip netns exec asicX show bfd summary and show bfd summary -n asicX are the same, and sudo ip netns exec asicX show bfd peer <peer_id> and show bfd peer <peer_id> -n asicX are the same

New command output (if the output of a command-line utility has changed) Nothing has changed to the output of these 2 commands, we are only adding the namespace argument support in this PR. Users can still use the sudo ip netns exec asicX  ... way after this PR.

I confirmed the output of sudo ip netns exec asicX show bfd summary and show bfd summary -n asicX are the same, and sudo ip netns exec asicX show bfd peer <peer_id> and show bfd peer <peer_id> -n asicX are the same

co-authorized by: jianquanye@microsoft.com

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

