### PR TITLE
refactor: enhance show bfd summary command (#4242)

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -2260,22 +2260,29 @@ def summary(db, namespace):
                 "TX Interval", "RX Interval", "Multiplier", "Multihop", "Local Discriminator"]
 
     if namespace is None:
-        namespace = constants.DEFAULT_NAMESPACE
+        if multi_asic.is_multi_asic():
+            namespace_list = multi_asic.get_namespace_list()
+        else:
+            namespace_list = [constants.DEFAULT_NAMESPACE]
+    else:
+        namespace_list = [namespace]
 
-    bfd_keys = db.db_clients[namespace].keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*")
-
-    click.echo("Total number of BFD sessions: {}".format(0 if bfd_keys is None else len(bfd_keys)))
-
+    total_bfd_sessions = 0
     bfd_body = []
-    if bfd_keys is not None:
+    for ns in namespace_list:
+        bfd_keys = db.db_clients[ns].keys(db.db.STATE_DB, "BFD_SESSION_TABLE|*")
+        if bfd_keys is None:
+            continue
+        total_bfd_sessions += len(bfd_keys)
         for key in bfd_keys:
             key_values = key.split('|')
-            values = db.db_clients[namespace].get_all(db.db.STATE_DB, key)
+            values = db.db_clients[ns].get_all(db.db.STATE_DB, key)
             if "local_discriminator" not in values.keys():
                 values["local_discriminator"] = "NA"
             bfd_body.append([key_values[3], key_values[2], key_values[1], values["state"], values["type"], values["local_addr"],
                                 values["tx_interval"], values["rx_interval"], values["multiplier"], values["multihop"], values["local_discriminator"]])
 
+    click.echo("Total number of BFD sessions: {}".format(total_bfd_sessions))
     click.echo(tabulate(bfd_body, bfd_headers))
 
 

--- a/tests/bfd_input/bfd_masic_test_vectors.py
+++ b/tests/bfd_input/bfd_masic_test_vectors.py
@@ -8,6 +8,18 @@ Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Int
 10.0.1.1     default      VrfRed   UP       async_active  10.0.0.1                400            500             5  false       NA
 """  # noqa: E501
 
+expected_show_bfd_summary_all_output = """\
+Total number of BFD sessions: 6
+Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
+-----------  -----------  -------  -------  ------------  ------------  -------------  -------------  ------------  ----------  ---------------------
+10.0.1.1     default      default  DOWN     async_active  10.0.0.1                300            500             3  true        NA
+10.0.2.1     Ethernet12   default  UP       async_active  10.0.0.1                200            600             3  false       88
+2000::10:1   default      default  UP       async_active  2000::1                 100            700             3  false       NA
+10.0.1.1     default      VrfRed   UP       async_active  10.0.0.1                400            500             5  false       NA
+10.0.3.1     Ethernet36   default  DOWN     async_active  10.0.0.2                150            450             3  true        99
+2000::20:1   default      VrfBlue  UP       async_active  2000::2                 250            750             4  false       NA
+"""  # noqa: E501
+
 expected_show_bfd_peer_output = """\
 Total number of BFD sessions for peer IP 10.0.1.1: 2
 Peer Addr    Interface    Vrf      State    Type          Local Addr      TX Interval    RX Interval    Multiplier  Multihop    Local Discriminator
@@ -21,6 +33,11 @@ test_data = {
         "cmd": "summary",
         "args": ["-n", "asic0"],
         "expected_output": expected_show_bfd_summary_output,
+    },
+    "show_bfd_summary_masic_all": {
+        "cmd": "summary",
+        "args": [],
+        "expected_output": expected_show_bfd_summary_all_output,
     },
     "show_bfd_peer_masic_asic0": {
         "cmd": "peer",

--- a/tests/mock_tables/asic1/state_db.json
+++ b/tests/mock_tables/asic1/state_db.json
@@ -280,5 +280,24 @@
     },
     "PORT_CAPACITY_TABLE|PORT_CAPACITY_DATA" : {
         "capacity": "80000"
+    },
+    "BFD_SESSION_TABLE|default|Ethernet36|10.0.3.1": {
+        "state": "DOWN",
+        "type": "async_active",
+        "local_addr" : "10.0.0.2",
+        "tx_interval" :"150",
+        "rx_interval" : "450",
+        "multiplier" : "3",
+        "multihop": "true",
+        "local_discriminator": "99"
+    },
+    "BFD_SESSION_TABLE|VrfBlue|default|2000::20:1": {
+        "state": "UP",
+        "type": "async_active",
+        "local_addr" : "2000::2",
+        "tx_interval" :"250",
+        "rx_interval" : "750",
+        "multiplier" : "4",
+        "multihop": "false"
     }
 }

--- a/tests/multi_asic_show_bfd_test.py
+++ b/tests/multi_asic_show_bfd_test.py
@@ -32,6 +32,9 @@ class TestShowBfdMultiAsic(object):
     def test_show_bfd_summary_masic_asic0(self):
         self.command_executor(test_data["show_bfd_summary_masic_asic0"])
 
+    def test_show_bfd_summary_masic_all(self):
+        self.command_executor(test_data["show_bfd_summary_masic_all"])
+
     def test_show_bfd_peer_masic_asic0(self):
         self.command_executor(test_data["show_bfd_peer_masic_asic0"])
 


### PR DESCRIPTION
Update show bfd summary to aggregate BFD sessions across all ASIC namespaces when no -n <namespace> is provided. Extend multi-ASIC BFD tests and expected output for the all-ASIC summary.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

