### PR TITLE
[202503] : Backport PR3819 to add multi-asic support for show interface counters fec-histogram CLI command

### DIFF
--- a/show/interfaces/__init__.py
+++ b/show/interfaces/__init__.py
@@ -3,6 +3,7 @@ import os
 
 import subprocess
 import click
+from utilities_common import constants
 import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
 from natsort import natsorted
@@ -801,35 +802,21 @@ def fec_stats(namespace, display, period, json_fmt, verbose):
     clicommon.run_command(cmd, display_cmd=verbose)
 
 
-def get_port_oid_mapping():
+def get_port_oid_mapping(db, namespace):
     ''' Returns dictionary of all ports interfaces and their OIDs. '''
-    db = SonicV2Connector(host=REDIS_HOSTIP)
-    db.connect(db.COUNTERS_DB)
-
-    port_oid_map = db.get_all(db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')
-
-    db.close(db.COUNTERS_DB)
-
+    port_oid_map = db.db_clients[namespace].get_all(db.db.COUNTERS_DB, 'COUNTERS_PORT_NAME_MAP')
     return port_oid_map
 
 
-def fetch_fec_histogram(port_oid_map, target_port):
+def fetch_fec_histogram(db, namespace, port_oid_map, target_port):
     ''' Fetch and display FEC histogram for the given port. '''
-    asic_db = SonicV2Connector(host=REDIS_HOSTIP)
-    asic_db.connect(asic_db.ASIC_DB)
-
-    config_db = ConfigDBConnector()
-    config_db.connect()
-
-    counter_db = SonicV2Connector(host=REDIS_HOSTIP)
-    counter_db.connect(counter_db.COUNTERS_DB)
 
     if target_port not in port_oid_map:
         click.echo('Port {} not found in COUNTERS_PORT_NAME_MAP'.format(target_port), err=True)
         raise click.Abort()
 
     port_oid = port_oid_map[target_port]
-    asic_db_kvp = counter_db.get_all(counter_db.COUNTERS_DB, 'COUNTERS:{}'.format(port_oid))
+    asic_db_kvp = db.db_clients[namespace].get_all(db.db.COUNTERS_DB, 'COUNTERS:{}'.format(port_oid))
 
     if asic_db_kvp is not None:
 
@@ -848,24 +835,26 @@ def fetch_fec_histogram(port_oid_map, target_port):
         click.echo('No kvp found in ASIC DB for port {}, exiting'.format(target_port), err=True)
         raise click.Abort()
 
-    asic_db.close(asic_db.ASIC_DB)
-    config_db.close(config_db.CONFIG_DB)
-    counter_db.close(counter_db.COUNTERS_DB)
 
 
 # 'fec-histogram' subcommand ("show interfaces counters fec-histogram")
 @counters.command('fec-histogram')
 @multi_asic_util.multi_asic_click_options
 @click.argument('interfacename', required=True)
-def fec_histogram(interfacename, namespace, display):
+@clicommon.pass_db
+def fec_histogram(db, interfacename, namespace, display):
     """Show interface counters fec-histogram"""
-    port_oid_map = get_port_oid_mapping()
+
+    if namespace is None:
+        namespace = constants.DEFAULT_NAMESPACE
+
+    port_oid_map = get_port_oid_mapping(db, namespace)
 
     # Try to convert interface name from alias
     interfacename = try_convert_interfacename_from_alias(click.get_current_context(), interfacename)
 
     # Fetch and display the FEC histogram
-    fetch_fec_histogram(port_oid_map, interfacename)
+    fetch_fec_histogram(db, namespace, port_oid_map, interfacename)
 
 
 # 'rates' subcommand ("show interfaces counters rates")


### PR DESCRIPTION
Currently, show fec histogram CLI command provides option for namespace but is not using it. This is why the CLI command aborts and does not return any meaningful results on 202503. 

#### What I did

[PR3819](https://github.com/sonic-net/sonic-utilities/pull/3819) already fixes the underlying issue. This PR has already merged but it was not backported to 202503 branch

In this pull request, I have backported changes from PR3819 to fix the issue on multi-asic systems.

I've also opened another PR to backport the same changes to 202405 branch : https://github.com/Azure/sonic-utilities.msft/pull/287

#### How to verify it

Testing command returns expected output.

#### Previous command output (if the output of a command-line utility has changed)

```
(switch)~# show interface counters fec-histogram -n asic0 Ethernet0
Port Ethernet0 not found in COUNTERS_PORT_NAME_MAP
Aborted!
```

#### New command output (if the output of a command-line utility has changed)

With the changes from this PR, the CLI command return following expected output

```
(switch):~$ show interfaces counters fec-histogram -n asic0 Ethernet0
Symbol Errors Per Codeword      Codewords
----------------------------  -----------
BIN0                                    0
BIN1                                    0
BIN2                                    0
BIN3                                    0
BIN4                                    0
BIN5                                    0
BIN6                                    0
BIN7                                    0
BIN8                                    0
BIN9                                    0
BIN10                                   0
BIN11                                   0
BIN12                                   0
BIN13                                   0
BIN14                                   0
BIN15                                   0
```