### PR TITLE
Add scope to field validator.[redo PR: 3675] (#3805)

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -8,6 +8,8 @@ from .gu_common import GenericConfigUpdaterError
 from swsscommon import swsscommon
 from utilities_common.constants import DEFAULT_SUPPORTED_FECS_LIST
 
+STATE_DB_NAME = 'STATE_DB'
+REDIS_TIMEOUT_MSECS = 0
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 GCU_TABLE_MOD_CONF_FILE = f"{SCRIPT_DIR}/gcu_field_operation_validators.conf.json"
 GET_HWSKU_CMD = "sonic-cfggen -d -v DEVICE_METADATA.localhost.hwsku"
@@ -88,7 +90,7 @@ def buffer_profile_config_update_validator(patch_element):
     return rdma_config_update_validator(patch_element)
 
 
-def rdma_config_update_validator(patch_element):
+def rdma_config_update_validator(scope, patch_element):
     asic = get_asic_name()
     if asic == "unknown":
         return False
@@ -161,17 +163,17 @@ def rdma_config_update_validator(patch_element):
     return True
 
 
-def read_statedb_entry(table, key, field):
-    state_db = swsscommon.DBConnector("STATE_DB", 0)
+def read_statedb_entry(scope, table, key, field):
+    state_db = swsscommon.DBConnector(STATE_DB_NAME, REDIS_TIMEOUT_MSECS, True, scope)
     tbl = swsscommon.Table(state_db, table)
     return tbl.hget(key, field)[1]
 
 
-def port_config_update_validator(patch_element):
+def port_config_update_validator(scope, patch_element):
 
     def _validate_field(field, port, value):
         if field == "fec":
-            supported_fecs_str = read_statedb_entry("PORT_TABLE", port, "supported_fecs")
+            supported_fecs_str = read_statedb_entry(scope, "PORT_TABLE", port, "supported_fecs")
             if supported_fecs_str:
                 if supported_fecs_str != 'N/A':
                     supported_fecs_list = [element.strip() for element in supported_fecs_str.split(',')]
@@ -186,7 +188,7 @@ def port_config_update_validator(patch_element):
             # For chassis, skip speed validation as desired speed is not in supported_speeds of StateDB.
             if device_info.is_chassis():
                 return True
-            supported_speeds_str = read_statedb_entry("PORT_TABLE", port, "supported_speeds") or ''
+            supported_speeds_str = read_statedb_entry(scope, "PORT_TABLE", port, "supported_speeds") or ''
             try:
                 supported_speeds = [int(s) for s in supported_speeds_str.split(',') if s]
                 if supported_speeds and int(value) not in supported_speeds:

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -189,7 +189,7 @@ class ConfigWrapper:
                 raise GenericConfigUpdaterError("Attempting to call invalid method {} in module {}. Module must be generic_config_updater.field_operation_validators, and method must be a defined validator".format(method_name, module_name))
             module = importlib.import_module(module_name, package=None)
             method_to_call = getattr(module, method_name)
-            return method_to_call(jsonpatch_element)
+            return method_to_call(self.scope, jsonpatch_element)
 
         if os.path.exists(GCU_FIELD_OP_CONF_FILE):
             with open(GCU_FIELD_OP_CONF_FILE, "r") as s:

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -1,6 +1,6 @@
 import io
-import unittest
 import mock
+import unittest
 import json
 import subprocess
 import generic_config_updater
@@ -17,17 +17,23 @@ class TestValidateFieldOperation(unittest.TestCase):
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
     def test_port_config_update_validator_valid_speed_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+            port_config_update_validator(scope, patch_element) == True
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="40000,30000"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "xyz"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == False
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": "234"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) == True
 
     @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=True))
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
@@ -35,8 +41,9 @@ class TestValidateFieldOperation(unittest.TestCase):
     def test_port_config_update_validator_invalid_speed_for_chassis(self):
         # 235 is in supported speeds, but for chassis, skip speed validation
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": 235}}
-        assert generic_config_updater.field_operation_validators.\
-            port_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=False))
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
@@ -44,8 +51,9 @@ class TestValidateFieldOperation(unittest.TestCase):
     def test_port_config_update_validator_valid_speed_for_nonchassis(self):
         # 234 is not in supported speeds, but for chassis, skip speed validation
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": 234}}
-        assert generic_config_updater.field_operation_validators.\
-            port_config_update_validator(patch_element) is True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("sonic_py_common.device_info.is_chassis", mock.MagicMock(return_value=False))
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
@@ -53,94 +61,127 @@ class TestValidateFieldOperation(unittest.TestCase):
     def test_port_config_update_validator_invalid_speed_for_nonchassis(self):
         # 235 is not in supported speeds, but for chassis, skip speed validation
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"speed": 235}}
-        assert generic_config_updater.field_operation_validators.\
-            port_config_update_validator(patch_element) is False
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry",
            mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "234"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/speed", "op": "add", "value": "235"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested(self):
         patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "speed": "235"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_valid_speed_existing_state_db_nested(self):
         patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "speed": "234"}, "Ethernet4": {"alias": "Eth4", "speed": "234"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="123,234"))
     def test_port_config_update_validator_invalid_speed_existing_state_db_nested_2(self):
         patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "speed": "234"}, "Ethernet4": {"alias": "Eth4", "speed": "236"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+
     def test_port_config_update_validator_remove(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_invalid_fec_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "asf"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_invalid_fec_existing_state_db_nested(self):
         patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "fec": "none"}, "Ethernet4": {"alias": "Eth4", "fec": "fs"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested(self):
         patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "fec": "fc"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db_nested_2(self):
         patch_element = {"path": "/PORT", "op": "add", "value": {"Ethernet3": {"alias": "Eth0", "fec": "rs"}, "Ethernet4": {"alias": "Eth4", "fec": "fc"}}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value="rs, fc"))
     def test_port_config_update_validator_valid_fec_existing_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rs"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
 
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
     def test_port_config_update_validator_valid_fec_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3", "op": "add", "value": {"fec": "rs"}}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == True
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is True
+
     @patch("generic_config_updater.field_operation_validators.read_statedb_entry", mock.Mock(return_value=""))
     def test_port_config_update_validator_invalid_fec_no_state_db(self):
         patch_element = {"path": "/PORT/Ethernet3/fec", "op": "add", "value": "rsf"}
-        assert generic_config_updater.field_operation_validators.port_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                port_config_update_validator(scope, patch_element) is False
+
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="unknown"))
     def test_rdma_config_update_validator_unknown_asic(self):
         patch_element = {"path": "/PFC_WD/Ethernet4/restoration_time", "op": "replace", "value": "234234"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
-        
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is False
+
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="td3"))
     @patch("os.path.exists", mock.Mock(return_value=True))
     @patch("builtins.open", mock_open(read_data='{"tables": {"BUFFER_POOL": {"validator_data": {"rdma_config_update_validator": {"Shared/headroom pool size changes": {"fields": ["ingress_lossless_pool/xoff", "ingress_lossless_pool/size", "egress_lossy_pool/size"], "operations": ["replace"], "platforms": {"td3": "20221100"}}}}}}}'))
     def test_rdma_config_update_validator_td3_asic_invalid_version(self):
         patch_element = {"path": "/BUFFER_POOL/ingress_lossless_pool/xoff", "op": "replace", "value": "234234"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is False
+
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
     @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": {"PFCWD enable/disable": {"fields": ["detection_time", "action"], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_valid_version_remove(self):
         patch_element = {"path": "/PFC_WD/Ethernet8/detection_time", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == True
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is True
 
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
@@ -148,38 +189,46 @@ class TestValidateFieldOperation(unittest.TestCase):
     @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": {"PFCWD enable/disable": {"fields": ["detection_time", "restoration_time", "action"], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_valid_version_add_pfcwd(self):
         patch_element = {"path": "/PFC_WD/Ethernet8", "op": "add", "value": {"action": "drop", "detection_time": "300", "restoration_time": "200"}}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == True
-   
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is True
+
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
     @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": {"PFCWD enable/disable": {"fields": ["detection_time", "action", ""], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_valid_version(self):
         patch_element = {"path": "/PFC_WD/Ethernet8", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == True
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is True
+
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
     @patch("builtins.open", mock_open(read_data='{"tables": {"BUFFER_POOL": {"validator_data": {"rdma_config_update_validator": {"Shared/headroom pool size changes": {"fields": ["ingress_lossless_pool/xoff", "egress_lossy_pool/size"], "operations": ["replace"], "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_invalid_op(self):
         patch_element = {"path": "/BUFFER_POOL/ingress_lossless_pool/xoff", "op": "remove"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is False
+
     @patch("sonic_py_common.device_info.get_sonic_version_info", mock.Mock(return_value={"build_version": "SONiC.20220530"}))
     @patch("generic_config_updater.field_operation_validators.get_asic_name", mock.Mock(return_value="spc1"))
     @patch("os.path.exists", mock.Mock(return_value=True))
     @patch("builtins.open", mock_open(read_data='{"tables": {"PFC_WD": {"validator_data": {"rdma_config_update_validator": {"PFCWD enable/disable": {"fields": ["detection_time", "action"], "operations": ["remove", "replace", "add"], "platforms": {"spc1": "20181100"}}}}}}}'))
     def test_rdma_config_update_validator_spc_asic_other_field(self):
         patch_element = {"path": "/PFC_WD/Ethernet8/other_field", "op": "add", "value": "sample_value"}
-        assert generic_config_updater.field_operation_validators.rdma_config_update_validator(patch_element) == False
-    
+        for scope in ["localhost", "asic0"]:
+            assert generic_config_updater.field_operation_validators.\
+                rdma_config_update_validator(scope, patch_element) is False
+
     def test_validate_field_operation_illegal__pfcwd(self):
         old_config = {"PFC_WD": {"GLOBAL": {"POLL_INTERVAL": "60"}}}
         target_config = {"PFC_WD": {"GLOBAL": {}}}
         config_wrapper = gu_common.ConfigWrapper()
         self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
-    
+
     def test_validate_field_operation_legal__rm_loopback1(self):
         old_config = {
             "LOOPBACK_INTERFACE": {
@@ -197,7 +246,7 @@ class TestValidateFieldOperation(unittest.TestCase):
         }
         config_wrapper = gu_common.ConfigWrapper()
         config_wrapper.validate_field_operation(old_config, target_config)
-        
+
     def test_validate_field_operation_illegal__rm_loopback0(self):
         old_config = {
             "LOOPBACK_INTERFACE": {
@@ -224,39 +273,44 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-D48C8", 0]
-        self.assertEqual(fov.get_asic_name(), "spc1")
-    
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "spc1")
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_spc2(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["ACS-MSN3800", 0]
-        self.assertEqual(fov.get_asic_name(), "spc2")
-    
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "spc2")
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_spc3(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN4600C-C64", 0]
-        self.assertEqual(fov.get_asic_name(), "spc3")
-    
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "spc3")
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_spc4(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["ACS-SN5600", 0]
-        self.assertEqual(fov.get_asic_name(), "spc4")
-    
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "spc4")
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_spc4(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'mellanox'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Mellanox-SN2700-A1", 0]
-        self.assertEqual(fov.get_asic_name(), "spc1")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "spc1")
 
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
@@ -264,32 +318,36 @@ class TestGetAsicName(unittest.TestCase):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Force10-S6100", 0]
-        self.assertEqual(fov.get_asic_name(), "th")
-    
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "th")
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_th2(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7260CX3-D108C8", 0]
-        self.assertEqual(fov.get_asic_name(), "th2")
-    
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "th2")
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_td2(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Force10-S6000", 0]
-        self.assertEqual(fov.get_asic_name(), "td2")
-    
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "td2")
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_td3(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
         mock_popen.return_value = mock.Mock()
         mock_popen.return_value.communicate.return_value = ["Arista-7050CX3-32S-C32", 0]
-        self.assertEqual(fov.get_asic_name(), "td3")
-    
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "td3")
+
     @patch('sonic_py_common.device_info.get_sonic_version_info')
     @patch('subprocess.Popen')
     def test_get_asic_j2cplus(self, mock_popen, mock_get_sonic_version_info):
@@ -310,7 +368,8 @@ class TestGetAsicName(unittest.TestCase):
     @patch('subprocess.Popen')
     def test_get_asic_cisco(self, mock_popen, mock_get_sonic_version_info):
         mock_get_sonic_version_info.return_value = {'asic_type': 'cisco-8000'}
-        self.assertEqual(fov.get_asic_name(), "cisco-8000")
+        for scope in ["localhost", "asic0"]:
+            self.assertEqual(fov.get_asic_name(), "cisco-8000")
 
     def test_buffer_profile_config_update_validator_object_level_remove(self):
         """Test that object-level remove operations are allowed (fixes rollback issue)"""


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

What I did
This is for fix issue:https://github.com/sonic-net/sonic-buildimage/issues/20379. It was done by https://github.com/sonic-net/sonic-utilities/pull/3675. and it was reverted by https://github.com/sonic-net/sonic-utilities/pull/3689.

This is redo by removing unnecessary change that caused PR test failure.

How I did it
For field_operation_validators, add scope if need read state_db.

How to verify it
admin@str2-7250-lc1-2:~$ sonic-db-cli STATE_DB -n asic0 hget "PORT_TABLE|Ethernet0" supported_fecs
none,rs

admin@str2-7250-lc1-2:~$ cat fec.json 
[
    {
        "op": "add",
        "path": "/asic0/PORT/Ethernet0/fec",
        "value": "fc"
    }
]

admin@str2-7250-lc1-2:~$ sudo config apply-patch fec.json 
Patch Applier: asic0: Patch application starting.
Patch Applier: asic0: Patch: [{"op": "add", "path": "/PORT/Ethernet0/fec", "value": "fc"}]
Patch Applier: asic0 getting current config db.
Patch Applier: asic0: simulating the target full config after applying the patch.
Patch Applier: asic0: validating all JsonPatch operations are permitted on the specified fields
Failed to apply patch due to: Failed to apply patch on the following scopes:
- asic0: Modification of PORT table is illegal- validating function generic_config_updater.field_operation_validators.port_config_update_validator returned False
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try "config apply-patch -h" for help.

Error: Failed to apply patch on the following scopes:
- asic0: Modification of PORT table is illegal- validating function generic_config_updater.field_operation_validators.port_config_update_validator returned False
Previous command output (if the output of a command-line utility has changed)
New command output (if the output of a command-line utility has changed)

