### PR TITLE
Change sensorshow conn to use TCP socket

### DIFF
--- a/scripts/sensorshow
+++ b/scripts/sensorshow
@@ -37,7 +37,7 @@ CURRENT_INFO_TABLE_NAME = 'CURRENT_INFO'
 
 class SensorShow(object):
     def __init__(self, type):
-        self.db = SonicV2Connector(use_unix_socket_path=True)
+        self.db = SonicV2Connector(use_unix_socket_path=False)
         self.db.connect(self.db.STATE_DB)
         self.field_name = type
         header[1] = type.capitalize()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Change the DB connection in `scripts/sensorshow` to use TCP socket.

#### How I did it

#### How to verify it
Run the commands that invoke `sensorshow` (e.g. `show platform voltage`) without `write` permission to see if it's returning the correct output instead of the `RuntimeError: Unable to connect to redis (unix-socket) - Permission denied(1): Cannot assign requested address` error

#### Previous command output (if the output of a command-line utility has changed)
 `RuntimeError: Unable to connect to redis (unix-socket) - Permission denied(1): Cannot assign requested address` 

#### New command output (if the output of a command-line utility has changed)
```
user@SONiC-DUT-sup00:~$ show platform voltage  
         Sensor    Voltage    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
---------------  ---------  ---------  --------  --------------  -------------  ---------  -----------------
FC0_HOTSWAP_VIN   55275 mV      58860     49140           59400          48600      False  20260310 03:04:31
FC2_HOTSWAP_VIN   55350 mV      58860     49140           59400          48600      False  20260310 03:04:31
FC4_HOTSWAP_VIN   55300 mV      58860     49140           59400          48600      False  20260310 03:04:31
FC5_HOTSWAP_VIN   55275 mV      58860     49140           59400          48600      False  20260310 03:04:31
FC6_HOTSWAP_VIN   55250 mV      58860     49140           59400          48600      False  20260310 03:04:31
     MB_VP54P0V   55350 mV      59343     48806           59913          48298      False  20260310 03:04:31
```
