### PR TITLE
Fix: remove hidden U+200E character from skip_sort_tables.txt in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
         'sonic_cli_gen',
     ],
     package_data={
-        'generic_config_updater': ['gcu_services_validator.conf.json', 'gcu_field_operation_validators.conf.json', 'skip_sort_tables.txt‎'],
+        'generic_config_updater': ['gcu_services_validator.conf.json', 'gcu_field_operation_validators.conf.json', 'skip_sort_tables.txt'],
         'show': ['aliases.ini'],
         'sonic_installer': ['aliases.ini'],
         'tests': ['acl_input/*',


### PR DESCRIPTION
Removes a hidden Unicode Left-to-Right Mark (U+200E) character that was appended to `skip_sort_tables.txt` on line 93 of `setup.py`. This invisible character could cause file lookup failures.