### PR TITLE
Fix buffer_profile GCU validator to pass scope to rdma_config_update_validator

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -62,11 +62,13 @@ def get_asic_name():
     return asic
 
 
-def buffer_profile_config_update_validator(patch_element):
+def buffer_profile_config_update_validator(scope, patch_element):
     """
     Enhanced buffer profile validator that handles both field-level and object-level operations.
     - Field-level operations (e.g., /BUFFER_PROFILE/profile/dynamic_th) follow existing rules
     - Object-level operations (e.g., /BUFFER_PROFILE/profile) allow remove operations
+
+    scope: same as other GCU validators (e.g. localhost, asic0); forwarded to rdma_config_update_validator.
     """
     path = patch_element["path"]
     path_parts = jsonpointer.JsonPointer(path).parts
@@ -87,7 +89,7 @@ def buffer_profile_config_update_validator(patch_element):
             return False  # Disallow unsupported operations
 
     # For field-level operations, use the existing validation logic
-    return rdma_config_update_validator(patch_element)
+    return rdma_config_update_validator(scope, patch_element)
 
 
 def rdma_config_update_validator(scope, patch_element):

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -379,7 +379,7 @@ class TestGetAsicName(unittest.TestCase):
         }
 
         # Object-level remove should be allowed without ASIC/version validation
-        assert fov.buffer_profile_config_update_validator(patch_element) is True
+        assert fov.buffer_profile_config_update_validator("localhost", patch_element) is True
 
     def test_buffer_profile_config_update_validator_object_level_add(self):
         """Test that object-level add operations are allowed"""
@@ -390,7 +390,7 @@ class TestGetAsicName(unittest.TestCase):
         }
 
         # Object-level add should be allowed
-        assert fov.buffer_profile_config_update_validator(patch_element) is True
+        assert fov.buffer_profile_config_update_validator("localhost", patch_element) is True
 
     def test_buffer_profile_config_update_validator_object_level_unsupported_op(self):
         """Test that unsupported operations on object-level are denied"""
@@ -400,7 +400,7 @@ class TestGetAsicName(unittest.TestCase):
             "from": "/BUFFER_PROFILE/old_profile"
         }
 
-        assert fov.buffer_profile_config_update_validator(patch_element) is False
+        assert fov.buffer_profile_config_update_validator("localhost", patch_element) is False
 
     def test_buffer_profile_config_update_validator_field_level_uses_existing_validation(self):
         """Test that field-level operations use existing validation logic"""
@@ -413,4 +413,4 @@ class TestGetAsicName(unittest.TestCase):
         # Mock the existing validation to return True
         with patch("generic_config_updater.field_operation_validators.rdma_config_update_validator",
                    return_value=True):
-            assert fov.buffer_profile_config_update_validator(patch_element) is True
+            assert fov.buffer_profile_config_update_validator("localhost", patch_element) is True


### PR DESCRIPTION
Signed-off-by: anamehra <anamehra@cisco.com>


validate_field_operation invokes validators as (scope, patch_element). buffer_profile_config_update_validator only took patch_element and called rdma_config_update_validator with one argument, causing TypeError on field-level BUFFER_PROFILE patches. Accept scope and forward both arguments.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fixed GCU config rollback for buffer profile for 202405

#### How I did it
Fixed buffer_profile_config_update_validator signature to include scope.

#### How to verify it
Run rollback tests as part of test_update_cable_length.py

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
<img width="1706" height="232" alt="Screenshot 2026-04-20 at 7 32 40 PM" src="https://github.com/user-attachments/assets/dc2fe768-0033-4889-952a-48aed72fc665" />

