### PR TITLE
Fix command docker ps showing issue

### DIFF
--- a/sonic_package_manager/service_creator/creator.py
+++ b/sonic_package_manager/service_creator/creator.py
@@ -277,6 +277,7 @@ class ServiceCreator:
         render_ctx = {
             'docker_container_name': name,
             'docker_image_id': image_id,
+            'docker_image_name': package.entry.repository,
             'docker_image_run_opt': run_opt,
         }
         render_template(script_template, script_path, render_ctx, executable=True)


### PR DESCRIPTION
This a backport of https://github.com/sonic-net/sonic-utilities/pull/3791

**What I did**
Fix docker ps command showing image ID instead of name:tag issue.
It only impacts dhcp-relay, dhcp-server and macsec.

**How I did it**
render_ctx will provide name:tag and j2 template will use it instead of ID.

**How to verify it**
Previous command output (if the output of a command-line utility has changed)
```
root@qzd570:/etc/sonic# docker ps -a | grep macsec
c9cf538eae74   5a4a047d213b                             "/usr/local/bin/supe…"   3 days ago   Up 7 minutes             macsec1
031f09619347   5a4a047d213b                             "/usr/local/bin/supe…"   3 days ago   Up 6 minutes             macsec0
```

New command output (if the output of a command-line utility has changed)
```
root@qzd301:/# docker ps | grep -i macsec
99079683b0b4   docker-macsec-dbg:latest                 "/usr/local/bin/supe…"   27 hours ago   Up 8 hours              macsec0
d25dd3b09000   docker-macsec-dbg:latest                 "/usr/local/bin/supe…"   27 hours ago   Up 8 hours              macsec1
```