### PR TITLE
[202503] Fixes to populate missing asic_id and platform info, after golden config override

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2248,10 +2248,14 @@ def generate_sysinfo(cur_config, config_input, ns=None):
         asic_name = multi_asic.get_asic_id_from_name(ns)
         asic_id = multi_asic.get_asic_device_id(asic_name)
 
-    device_metadata['localhost']['mac'] = mac.rstrip('\n')
-    device_metadata['localhost']['platform'] = platform.rstrip('\n')
+    # Only backfill sysinfo fields if not explicitly provided in golden config
+    if 'mac' not in device_metadata['localhost']:
+        device_metadata['localhost']['mac'] = mac.rstrip('\n')
+    if 'platform' not in device_metadata['localhost']:
+        device_metadata['localhost']['platform'] = platform.rstrip('\n')
     if ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE and asic_id:
-        device_metadata['localhost']['asic_id'] = asic_id.rstrip('\n')
+        if 'asic_id' not in device_metadata['localhost']:
+            device_metadata['localhost']['asic_id'] = asic_id.rstrip('\n')
 
     return
 

--- a/config/main.py
+++ b/config/main.py
@@ -2250,7 +2250,7 @@ def generate_sysinfo(cur_config, config_input, ns=None):
 
     device_metadata['localhost']['mac'] = mac.rstrip('\n')
     device_metadata['localhost']['platform'] = platform.rstrip('\n')
-    if ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+    if ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE and asic_id:
         device_metadata['localhost']['asic_id'] = asic_id.rstrip('\n')
 
     return

--- a/config/main.py
+++ b/config/main.py
@@ -2217,12 +2217,16 @@ def generate_sysinfo(cur_config, config_input, ns=None):
 
     mac = None
     platform = None
+    asic_id = None
     cur_device_metadata = cur_config.get('DEVICE_METADATA')
 
-    # Reuse current config's mac and platform. Generate if absent
+    # Reuse the existing configuration's MAC address, platform, and asic_id
+    # if available; generate these values only if they are missing.
     if cur_device_metadata is not None:
         mac = cur_device_metadata.get('localhost', {}).get('mac')
         platform = cur_device_metadata.get('localhost', {}).get('platform')
+        if ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+            asic_id = cur_device_metadata.get('localhost', {}).get('asic_id')
 
     if not mac:
         if ns:
@@ -2240,8 +2244,14 @@ def generate_sysinfo(cur_config, config_input, ns=None):
     if not platform:
         platform = device_info.get_platform()
 
-    device_metadata['localhost']['mac'] = mac
-    device_metadata['localhost']['platform'] = platform
+    if not asic_id and ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+        asic_name = multi_asic.get_asic_id_from_name(ns)
+        asic_id = multi_asic.get_asic_device_id(asic_name)
+
+    device_metadata['localhost']['mac'] = mac.rstrip('\n')
+    device_metadata['localhost']['platform'] = platform.rstrip('\n')
+    if ns != DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+        device_metadata['localhost']['asic_id'] = asic_id.rstrip('\n')
 
     return
 

--- a/tests/config_override_input/multi_asic_dm_explicit_sysinfo.json
+++ b/tests/config_override_input/multi_asic_dm_explicit_sysinfo.json
@@ -1,0 +1,61 @@
+{
+    "localhost": {
+        "DEVICE_METADATA": {
+            "localhost": {
+                "default_bgp_status": "down",
+                "default_pfcwd_status": "enable",
+                "deployment_id": "1",
+                "docker_routing_config_mode": "separated",
+                "hostname": "sonic-switch",
+                "hwsku": "Mellanox-SN3800-D112C8",
+                "peer_switch": "sonic-switch",
+                "type": "ToRRouter",
+                "suppress-fib-pending": "enabled",
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "platform": "custom-platform"
+            }
+        }
+    },
+    "asic0": {
+        "DEVICE_METADATA": {
+            "localhost": {
+                "asic_name": "asic0",
+                "bgp_asn": "65100",
+                "cloudtype": "None",
+                "default_bgp_status": "down",
+                "default_pfcwd_status": "enable",
+                "deployment_id": "None",
+                "docker_routing_config_mode": "separated",
+                "hostname": "sonic",
+                "hwsku": "multi_asic",
+                "region": "None",
+                "sub_role": "FrontEnd",
+                "type": "LeafRouter",
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "platform": "custom-platform",
+                "asic_id": "ff:00:00"
+            }
+        }
+    },
+    "asic1": {
+        "DEVICE_METADATA": {
+            "localhost": {
+                "asic_name": "asic1",
+                "bgp_asn": "65100",
+                "cloudtype": "None",
+                "default_bgp_status": "down",
+                "default_pfcwd_status": "enable",
+                "deployment_id": "None",
+                "docker_routing_config_mode": "separated",
+                "hostname": "sonic",
+                "hwsku": "multi_asic",
+                "region": "None",
+                "sub_role": "BackEnd",
+                "type": "LeafRouter",
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "platform": "custom-platform",
+                "asic_id": "ff:00:00"
+            }
+        }
+    }
+}

--- a/tests/config_override_input/multi_asic_dm_gen_sysinfo.json
+++ b/tests/config_override_input/multi_asic_dm_gen_sysinfo.json
@@ -17,7 +17,6 @@
     "asic0": {
         "DEVICE_METADATA": {
             "localhost": {
-                "asic_id": "01.00.0",
                 "asic_name": "asic0",
                 "bgp_asn": "65100",
                 "cloudtype": "None",
@@ -36,7 +35,6 @@
     "asic1": {
         "DEVICE_METADATA": {
             "localhost": {
-                "asic_id": "08:00.0",
                 "asic_name": "asic1",
                 "bgp_asn": "65100",
                 "cloudtype": "None",

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -415,6 +415,45 @@ class TestConfigOverrideMultiasic(object):
                 asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
                 assert asic_id == "06:00:00"
 
+    def test_device_metadata_gen_sysinfo_without_change_asic_id(self):
+        def read_json_file_side_effect(filename):
+            with open(MULTI_ASIC_DEVICE_METADATA_GEN_SYSINFO, "r") as f:
+                device_metadata = json.load(f)
+            return device_metadata
+        db = Db()
+        cfgdb_clients = db.cfgdb_clients
+
+        # Remove original sysinfo and check if use generated ones
+        for ns, config_db in cfgdb_clients.items():
+            metadata = config_db.get_config()['DEVICE_METADATA']['localhost']
+            metadata.pop('platform', None)
+            metadata.pop('mac', None)
+            if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+                metadata.pop('asic_id', None)
+            config_db.set_entry('DEVICE_METADATA', 'localhost', metadata)
+
+        with mock.patch('config.main.read_json_file',
+                        mock.MagicMock(side_effect=read_json_file_side_effect)),\
+             mock.patch('sonic_py_common.device_info.get_platform',
+                        return_value="multi_asic"),\
+             mock.patch('sonic_py_common.device_info.get_system_mac',
+                        return_value="11:22:33:44:55:66\n"),\
+             mock.patch('sonic_py_common.multi_asic.get_asic_device_id',
+                        return_value=None):
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["override-config-table"],
+                                   ['golden_config_db.json'], obj=db)
+            assert result.exit_code == 0
+
+        for ns, config_db in cfgdb_clients.items():
+            platform = config_db.get_config()['DEVICE_METADATA']['localhost'].get('platform')
+            mac = config_db.get_config()['DEVICE_METADATA']['localhost'].get('mac')
+            assert platform == "multi_asic"
+            assert mac == "11:22:33:44:55:66"
+            if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+                asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
+                assert asic_id is None
+
     def test_masic_missig_localhost_override(self):
         def read_json_file_side_effect(filename):
             with open(MULTI_ASIC_MISSING_LOCALHOST_OV, "r") as f:

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -25,6 +25,7 @@ FINAL_CONFIG_YANG_FAILURE = os.path.join(DATA_DIR, "final_config_yang_failure.js
 MULTI_ASIC_MACSEC_OV = os.path.join(DATA_DIR, "multi_asic_macsec_ov.json")
 MULTI_ASIC_FEATURE_RM = os.path.join(DATA_DIR, "multi_asic_feature_rm.json")
 MULTI_ASIC_DEVICE_METADATA_GEN_SYSINFO = os.path.join(DATA_DIR, "multi_asic_dm_gen_sysinfo.json")
+MULTI_ASIC_DEVICE_METADATA_EXPLICIT_SYSINFO = os.path.join(DATA_DIR, "multi_asic_dm_explicit_sysinfo.json")
 MULTI_ASIC_MISSING_LOCALHOST_OV = os.path.join(DATA_DIR, "multi_asic_missing_localhost.json")
 MULTI_ASIC_MISSING_ASIC_OV = os.path.join(DATA_DIR, "multi_asic_missing_asic.json")
 
@@ -453,6 +454,41 @@ class TestConfigOverrideMultiasic(object):
             if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
                 asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
                 assert asic_id is None
+
+    def test_device_metadata_explicit_sysinfo_override(self):
+        """Test that explicit mac/platform/asic_id in golden config are preserved."""
+        def read_json_file_side_effect(filename):
+            with open(MULTI_ASIC_DEVICE_METADATA_EXPLICIT_SYSINFO, "r") as f:
+                device_metadata = json.load(f)
+            return device_metadata
+        db = Db()
+        cfgdb_clients = db.cfgdb_clients
+
+        with mock.patch('config.main.read_json_file',
+                        mock.MagicMock(side_effect=read_json_file_side_effect)),\
+             mock.patch('sonic_py_common.device_info.get_platform',
+                        return_value="multi_asic"),\
+             mock.patch('sonic_py_common.device_info.get_system_mac',
+                        return_value="11:22:33:44:55:66\n"),\
+             mock.patch('sonic_py_common.multi_asic.get_asic_device_id',
+                        return_value="06:00:00\n"):
+            runner = CliRunner()
+            result = runner.invoke(config.config.commands["override-config-table"],
+                                   ['golden_config_db.json'], obj=db)
+            assert result.exit_code == 0
+
+        for ns, config_db in cfgdb_clients.items():
+            mac = config_db.get_config()['DEVICE_METADATA']['localhost'].get('mac')
+            platform = config_db.get_config()['DEVICE_METADATA']['localhost'].get('platform')
+            # Golden config explicit values should be preserved, not overwritten
+            assert mac == "aa:bb:cc:dd:ee:ff", \
+                f"Expected golden config mac 'aa:bb:cc:dd:ee:ff' but got '{mac}' for namespace '{ns}'"
+            assert platform == "custom-platform", \
+                f"Expected golden config platform 'custom-platform' but got '{platform}' for namespace '{ns}'"
+            if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+                asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
+                assert asic_id == "ff:00:00", \
+                    f"Expected golden config asic_id 'ff:00:00' but got '{asic_id}' for namespace '{ns}'"
 
     def test_masic_missig_localhost_override(self):
         def read_json_file_side_effect(filename):

--- a/tests/config_override_test.py
+++ b/tests/config_override_test.py
@@ -6,6 +6,7 @@ import config.main as config
 
 from click.testing import CliRunner
 from unittest import mock
+from generic_config_updater.gu_common import HOST_NAMESPACE
 from utilities_common.db import Db
 from utilities_common.general import load_module_from_source
 from minigraph import minigraph_encoder
@@ -355,6 +356,9 @@ class TestConfigOverrideMultiasic(object):
             orig_sysinfo[ns] = {}
             orig_sysinfo[ns]['platform'] = platform
             orig_sysinfo[ns]['mac'] = mac
+            if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+                asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
+                orig_sysinfo[ns]['asic_id'] = asic_id
 
         with mock.patch('config.main.read_json_file',
                 mock.MagicMock(side_effect=read_json_file_side_effect)):
@@ -368,6 +372,9 @@ class TestConfigOverrideMultiasic(object):
             mac = config_db.get_config()['DEVICE_METADATA']['localhost'].get('mac')
             assert platform == orig_sysinfo[ns]['platform']
             assert mac == orig_sysinfo[ns]['mac']
+            if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+                asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
+                assert asic_id == orig_sysinfo[ns]['asic_id']
 
     def test_device_metadata_gen_sysinfo(self):
         def read_json_file_side_effect(filename):
@@ -382,14 +389,18 @@ class TestConfigOverrideMultiasic(object):
             metadata = config_db.get_config()['DEVICE_METADATA']['localhost']
             metadata.pop('platform', None)
             metadata.pop('mac', None)
+            if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+                metadata.pop('asic_id', None)
             config_db.set_entry('DEVICE_METADATA', 'localhost', metadata)
 
         with mock.patch('config.main.read_json_file',
                         mock.MagicMock(side_effect=read_json_file_side_effect)),\
                 mock.patch('sonic_py_common.device_info.get_platform',
                         return_value="multi_asic"),\
-                mock.patch('sonic_py_common.device_info.get_system_mac',
-                        return_value="11:22:33:44:55:66"):
+             mock.patch('sonic_py_common.device_info.get_system_mac',
+                        return_value="11:22:33:44:55:66\n"),\
+             mock.patch('sonic_py_common.multi_asic.get_asic_device_id',
+                        return_value="06:00:00\n"):
             runner = CliRunner()
             result = runner.invoke(config.config.commands["override-config-table"],
                                    ['golden_config_db.json'], obj=db)
@@ -400,6 +411,9 @@ class TestConfigOverrideMultiasic(object):
             mac = config_db.get_config()['DEVICE_METADATA']['localhost'].get('mac')
             assert platform == "multi_asic"
             assert mac == "11:22:33:44:55:66"
+            if ns != config.DEFAULT_NAMESPACE and ns != HOST_NAMESPACE:
+                asic_id = config_db.get_config()['DEVICE_METADATA']['localhost'].get('asic_id')
+                assert asic_id == "06:00:00"
 
     def test_masic_missig_localhost_override(self):
         def read_json_file_side_effect(filename):


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix the issue where after golden-config override, asic-id is missing in DEVICE_METADATA preventing the asics from getting initialized on a multi-asic pizzabox

#### How I did it
Backport these to 202503:
https://github.com/sonic-net/sonic-utilities/pull/3711
https://github.com/sonic-net/sonic-utilities/pull/3820
https://github.com/sonic-net/sonic-utilities/pull/4348

#### How to verify it
Override golden config on a multi-asic device and verify asic-id and other platfom info are present in the DEVICE_METADATA of config DB

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

