### PR TITLE
[port_config_update_validator] Skip fec validation for chassis devices

### DIFF
--- a/generic_config_updater/field_operation_validators.py
+++ b/generic_config_updater/field_operation_validators.py
@@ -180,6 +180,9 @@ def port_config_update_validator(scope, patch_element):
 
     def _validate_field(field, port, value):
         if field == "fec":
+            # For chassis, skip fec validation as desired fec is not in supported_fecs of StateDB.
+            if device_info.is_chassis():
+                return True
             supported_fecs_str = read_statedb_entry(scope, "PORT_TABLE", port, "supported_fecs")
             if supported_fecs_str:
                 if supported_fecs_str != 'N/A':


### PR DESCRIPTION
## Description
For chassis devices, the desired FEC value may not appear in the `supported_fecs` field of STATE_DB `PORT_TABLE` — the same situation that already exists for `speed`.

This change mirrors the existing chassis handling for `speed` by adding an early `return True` in `_validate_field` when `field == "fec"` and `device_info.is_chassis()` is `True`.

## Changes
- **`generic_config_updater/field_operation_validators.py`**: In `port_config_update_validator._validate_field`, skip FEC STATE_DB validation on chassis devices (consistent with speed handling).

## Testing
- Existing unit tests for `port_config_update_validator` continue to pass on non-chassis paths.
- On a chassis device, FEC updates in the PORT table will no longer be blocked by missing `supported_fecs` entries in STATE_DB.