### PR TITLE
[202405][GCU] Backport #3831 perf refactor + #4118/#4335/#4668 fixes (parts 1-8)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: semgrep ci
         env:
-           SEMGREP_RULES: "p/default r/python.lang.security.audit.dangerous-system-call-audit.dangerous-system-call-audit"
+           SEMGREP_RULES: "p/default r/python.lang.security.audit.dangerous-system-call-audit.dangerous-system-call-audit .semgrep/"

--- a/.semgrep/no-direct-libyang.yml
+++ b/.semgrep/no-direct-libyang.yml
@@ -1,0 +1,21 @@
+rules:
+  - id: no-direct-libyang-import
+    patterns:
+      - pattern-either:
+          - pattern: import yang
+          - pattern: import yang as $X
+          - pattern: from yang import $X
+          - pattern: from yang import $X as $Y
+          - pattern: import libyang
+          - pattern: import libyang as $X
+          - pattern: from libyang import $X
+          - pattern: from libyang import $X as $Y
+    message: >-
+      Do not import libyang directly. sonic-utilities must go through
+      sonic_yang / sonic_yang_ext so that libyang API/ABI changes (libyang1
+      vs libyang2 vs libyang3) are isolated to sonic-yang-mgmt.
+    languages: [python]
+    severity: ERROR
+    paths:
+      exclude:
+        - tests/

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Currently, this list of dependencies is as follows:
 - libyang_1.0.73_amd64.deb
 - libyang-cpp_1.0.73_amd64.deb
 - python3-yang_1.0.73_amd64.deb
+- libyang3_3.*_amd64.deb
+- python3-libyang_3.*_amd64.deb
 - redis_dump_load-1.1-py3-none-any.whl
 - sonic_py_common-1.0-py3-none-any.whl
 - sonic_config_engine-1.0-py3-none-any.whl

--- a/config/config_mgmt.py
+++ b/config/config_mgmt.py
@@ -8,7 +8,6 @@ import re
 import shutil
 import syslog
 import tempfile
-import yang as ly
 from json import load
 from sys import flags
 from time import sleep as tsleep
@@ -35,8 +34,7 @@ class ConfigMgmt():
     to verify config for the commands which are capable of change in config DB.
     '''
 
-    def __init__(self, source="configDB", debug=False, allowTablesWithoutYang=True,
-                 sonicYangOptions=0, configdb=None):
+    def __init__(self, source="configDB", debug=False, allowTablesWithoutYang=True, configdb=None):
         '''
         Initialise the class, --read the config, --load in data tree.
 
@@ -55,7 +53,6 @@ class ConfigMgmt():
             self.configdbJsonOut = None
             self.source = source
             self.allowTablesWithoutYang = allowTablesWithoutYang
-            self.sonicYangOptions = sonicYangOptions
             self.configdb = configdb
 
             # logging vars
@@ -71,7 +68,7 @@ class ConfigMgmt():
         return
 
     def __init_sonic_yang(self):
-        self.sy = sonic_yang.SonicYang(YANG_DIR, debug=self.DEBUG, sonic_yang_options=self.sonicYangOptions)
+        self.sy = sonic_yang.SonicYang(YANG_DIR, debug=self.DEBUG)
         # load yang models
         self.sy.loadYangModel()
         # load jIn from config DB or from config DB json file.
@@ -291,8 +288,7 @@ class ConfigMgmt():
 
         # Instantiate new context since parse_module_mem() loads the module into context.
         sy = sonic_yang.SonicYang(YANG_DIR)
-        module = sy.ctx.parse_module_mem(yang_module_str, ly.LYS_IN_YANG)
-        return module.name()
+        return sy.load_module_str_name(yang_module_str)
 
 
 # End of Class ConfigMgmt

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -138,9 +138,10 @@ class PatchApplier:
         # Apply changes in order
         self.logger.log_notice(f"{scope}: applying {changes_len} change{'s' if changes_len != 1 else ''} " \
                                f"in order{':' if changes_len > 0 else '.'}")
+        current_config = old_config
         for change in changes:
             self.logger.log_notice(f"  * {change}")
-            self.changeapplier.apply(change)
+            current_config = self.changeapplier.apply(current_config, change)
 
         # Validate config updated successfully
         self.logger.log_notice(f"{scope}: verifying patch updates are reflected on ConfigDB.")

--- a/generic_config_updater/generic_updater.py
+++ b/generic_config_updater/generic_updater.py
@@ -1,11 +1,12 @@
 import json
+import jsonpatch
 import jsonpointer
 import os
 import subprocess
 
 from enum import Enum
 from .gu_common import HOST_NAMESPACE, GenericConfigUpdaterError, EmptyTableError, ConfigWrapper, \
-                    DryRunConfigWrapper, PatchWrapper, genericUpdaterLogging
+                    DryRunConfigWrapper, JsonChange, PatchWrapper, genericUpdaterLogging
 from .patch_sorter import StrictPatchSorter, NonStrictPatchSorter, ConfigSplitter, \
                         TablesWithoutYangConfigSplitter, IgnorePathsFromYangConfigSplitter
 from .change_applier import ChangeApplier, DryRunChangeApplier

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -5,7 +5,6 @@ from jsonpointer import JsonPointer
 import sonic_yang
 import sonic_yang_ext
 import subprocess
-import yang as ly
 import copy
 import re
 import os
@@ -524,10 +523,8 @@ class PathAddressing:
         # Iterate across all paths fetching references
         for path in paths:
             xpath = self.convert_path_to_xpath(path, config, sy)
-
-            leaf_xpaths = self._get_inner_leaf_xpaths(xpath, sy)
-            for xpath in leaf_xpaths:
-                ref_xpaths.extend(sy.find_data_dependencies(xpath))
+            # NOTE: This will recursively find dependencies for all decendents
+            ref_xpaths.extend(sy.find_data_dependencies(xpath))
 
         # For each xpath, convert to configdb path
         for ref_xpath in ref_xpaths:
@@ -538,22 +535,6 @@ class PathAddressing:
 
         ref_paths.sort()
         return ref_paths
-
-    def _get_inner_leaf_xpaths(self, xpath, sy):
-        if xpath == "/": # Point to Root element which contains all xpaths
-            nodes = sy.root.tree_for()
-        else: # Otherwise get all nodes that match xpath
-            nodes = sy.root.find_path(xpath).data()
-
-        for node in nodes:
-            for inner_node in node.tree_dfs():
-                # TODO: leaflist also can be used as the 'path' argument in 'leafref' so add support to leaflist
-                if self._is_leaf_node(inner_node):
-                    yield inner_node.path()
-
-    def _is_leaf_node(self, node):
-        schema = node.schema()
-        return ly.LYS_LEAF == schema.nodetype()
 
     def convert_path_to_xpath(self, path, config=None, sy=None):
         """

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -198,8 +198,6 @@ class ConfigWrapper:
                 if any(op['op'] == operation and field == op['path'] for op in patch):
                     raise IllegalPatchOperationError("Given patch operation is invalid. Operation: {} is illegal on field: {}".format(operation, field))
 
-        self.illegal_dataacl_check(old_config, target_config)
-
         def _invoke_validating_function(cmd, jsonpatch_element):
             # cmd is in the format as <package/module name>.<method name>
             method_name = cmd.split(".")[-1]

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -205,7 +205,7 @@ class ConfigWrapper:
                 raise GenericConfigUpdaterError("Attempting to call invalid method {} in module {}. Module must be generic_config_updater.field_operation_validators, and method must be a defined validator".format(method_name, module_name))
             module = importlib.import_module(module_name, package=None)
             method_to_call = getattr(module, method_name)
-            return method_to_call(jsonpatch_element)
+            return method_to_call(self.scope, jsonpatch_element)
 
         if os.path.exists(GCU_FIELD_OP_CONF_FILE):
             with open(GCU_FIELD_OP_CONF_FILE, "r") as s:

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -39,8 +39,8 @@ class JsonChange:
     def __init__(self, patch):
         self.patch = patch
 
-    def apply(self, config):
-        return self.patch.apply(config)
+    def apply(self, config, in_place: bool = False):
+        return self.patch.apply(config, in_place)
 
     def __repr__(self):
         return str(self)
@@ -334,10 +334,11 @@ class DryRunConfigWrapper(ConfigWrapper):
         self.logger = genericUpdaterLogging.get_logger(title="** DryRun", print_all_to_console=True)
         self.imitated_config_db = copy.deepcopy(initial_imitated_config_db)
 
-    def apply_change_to_config_db(self, change):
+    def apply_change_to_config_db(self, current_config_db: dict, change):
         self._init_imitated_config_db_if_none()
         self.logger.log_notice(f"Would apply {change}")
-        self.imitated_config_db = change.apply(self.imitated_config_db)
+        self.imitated_config_db = change.apply(current_config_db, in_place=True)
+        return self.imitated_config_db
 
     def get_config_db_as_json(self):
         self._init_imitated_config_db_if_none()

--- a/generic_config_updater/gu_common.py
+++ b/generic_config_updater/gu_common.py
@@ -12,6 +12,7 @@ import os
 import hashlib
 from sonic_py_common import logger, multi_asic
 from enum import Enum
+from functools import cmp_to_key
 
 YANG_DIR = "/usr/local/yang-models"
 SYSLOG_IDENTIFIER = "GenericConfigUpdater"
@@ -83,7 +84,6 @@ class ConfigWrapper:
         self.sonic_yang_with_loaded_models = None
         self._validate_config_cache = {}
         self._currently_loaded_hash = None
-        self._loaded_sy = None
 
     def get_config_db_as_json(self):
         return get_config_db_as_json(self.scope)
@@ -134,14 +134,17 @@ class ConfigWrapper:
         sy = self.create_sonic_yang_with_loaded_models()
 
         try:
+            # Loading data automatically does full validation
             sy.loadData(config_db_as_json)
-
-            sy.validate_data_tree()
             return True, None
         except sonic_yang.SonicYangException as ex:
             return False, ex
 
     def validate_config_db_config(self, config_db_as_json):
+        # Cache validation results by config content hash.
+        # validate_config_db_config is a pure function: same config always produces
+        # the same result. Caching avoids redundant loadData() calls when the DFS
+        # revisits the same config state during backtracking.
         _cache_key = hashlib.md5(
             json.dumps(config_db_as_json, sort_keys=True).encode()
         ).hexdigest()
@@ -155,12 +158,9 @@ class ConfigWrapper:
                                         self.validate_lanes]
 
         try:
+            # Loading data automatically does full validation
             sy.loadData(config_db_as_json)
             self._currently_loaded_hash = _cache_key
-            self._loaded_sy = sy
-
-            sy.validate_data_tree()
-
             for supplemental_yang_validator in supplemental_yang_validators:
                 success, error = supplemental_yang_validator(config_db_as_json)
                 if not success:
@@ -169,8 +169,7 @@ class ConfigWrapper:
                     return result
         except sonic_yang.SonicYangException as ex:
             self._currently_loaded_hash = None
-            self._loaded_sy = None
-            result = (False, ex)
+            result = (False, str(ex))
             self._validate_config_cache[_cache_key] = result
             return result
 
@@ -199,6 +198,8 @@ class ConfigWrapper:
                 if any(op['op'] == operation and field == op['path'] for op in patch):
                     raise IllegalPatchOperationError("Given patch operation is invalid. Operation: {} is illegal on field: {}".format(operation, field))
 
+        self.illegal_dataacl_check(old_config, target_config)
+
         def _invoke_validating_function(cmd, jsonpatch_element):
             # cmd is in the format as <package/module name>.<method name>
             method_name = cmd.split(".")[-1]
@@ -207,7 +208,7 @@ class ConfigWrapper:
                 raise GenericConfigUpdaterError("Attempting to call invalid method {} in module {}. Module must be generic_config_updater.field_operation_validators, and method must be a defined validator".format(method_name, module_name))
             module = importlib.import_module(module_name, package=None)
             method_to_call = getattr(module, method_name)
-            return method_to_call(self.scope, jsonpatch_element)
+            return method_to_call(jsonpatch_element)
 
         if os.path.exists(GCU_FIELD_OP_CONF_FILE):
             with open(GCU_FIELD_OP_CONF_FILE, "r") as s:
@@ -229,7 +230,6 @@ class ConfigWrapper:
             for function in validating_functions:
                 if not _invoke_validating_function(function, element):
                     raise IllegalPatchOperationError("Modification of {} table is illegal- validating function {} returned False".format(table, function))
-
 
     def validate_lanes(self, config_db):
         if "PORT" not in config_db:
@@ -294,10 +294,10 @@ class ConfigWrapper:
     def crop_tables_without_yang(self, config_db_as_json):
         sy = self.create_sonic_yang_with_loaded_models()
 
-        sy.jIn = copy.deepcopy(config_db_as_json)
-
+        # Current sonic-yang-mgmt guarantees _cropConfigDB() will deep copy if
+        # it needs to modify.
+        sy.jIn = config_db_as_json
         sy.tablesWithOutYang = dict()
-
         sy._cropConfigDB()
 
         return sy.jIn
@@ -325,7 +325,7 @@ class ConfigWrapper:
             loaded_models_sy.loadYangModel() # This call takes a long time (100s of ms) because it reads files from disk
             self.sonic_yang_with_loaded_models = loaded_models_sy
 
-        return copy.copy(self.sonic_yang_with_loaded_models)
+        return self.sonic_yang_with_loaded_models
 
 class DryRunConfigWrapper(ConfigWrapper):
     # This class will simulate all read/write operations to ConfigDB on a virtual storage unit.
@@ -438,11 +438,17 @@ class PathAddressing:
     def __init__(self, config_wrapper=None):
         self.config_wrapper = config_wrapper
 
-    def get_path_tokens(self, path):
-        return JsonPointer(path).parts
+    @staticmethod
+    def get_path_tokens(path):
+        return sonic_yang.SonicYang.configdb_path_split(path)
 
-    def create_path(self, tokens):
-        return JsonPointer.from_parts(tokens).path
+    @staticmethod
+    def create_path(tokens):
+        return sonic_yang.SonicYang.configdb_path_join(tokens)
+
+    @staticmethod
+    def get_xpath_tokens(xpath):
+        return sonic_yang.SonicYang.xpath_split(xpath)
 
     def has_path(self, doc, path):
         return self.get_from_path(doc, path) is not None
@@ -453,95 +459,10 @@ class PathAddressing:
     def is_config_different(self, path, current, target):
         return self.get_from_path(current, path) != self.get_from_path(target, path)
 
-    def get_xpath_tokens(self, xpath):
-        """
-        Splits the given xpath into tokens by '/'.
-
-        Example:
-          xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/tagging_mode
-          tokens: sonic-vlan:sonic-vlan, VLAN_MEMBER, VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8'], tagging_mode
-        """
-        if xpath == "":
-            raise ValueError("xpath cannot be empty")
-
-        if xpath == "/":
-            return []
-
-        idx = 0
-        tokens = []
-        while idx < len(xpath):
-            end = self._get_xpath_token_end(idx+1, xpath)
-            token = xpath[idx+1:end]
-            tokens.append(token)
-            idx = end
-
-        return tokens
-
-    def _get_xpath_token_end(self, start, xpath):
-        idx = start
-        while idx < len(xpath):
-            if xpath[idx] == PathAddressing.XPATH_SEPARATOR:
-                break
-            elif xpath[idx] == "[":
-                idx = self._get_xpath_predicate_end(idx, xpath)
-            idx = idx+1
-
-        return idx
-
-    def _get_xpath_predicate_end(self, start, xpath):
-        idx = start
-        while idx < len(xpath):
-            if xpath[idx] == "]":
-                break
-            elif xpath[idx] == "'":
-                idx = self._get_xpath_single_quote_str_end(idx, xpath)
-            elif xpath[idx] == '"':
-                idx = self._get_xpath_double_quote_str_end(idx, xpath)
-
-            idx = idx+1
-
-        return idx
-
-    def _get_xpath_single_quote_str_end(self, start, xpath):
-        idx = start+1 # skip first single quote
-        while idx < len(xpath):
-            if xpath[idx] == "'":
-                break
-            # libyang implements XPATH 1.0 which does not escape single quotes
-            # libyang src: https://netopeer.liberouter.org/doc/libyang/master/html/howtoxpath.html
-            # XPATH 1.0 src: https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Literal
-            idx = idx+1
-
-        return idx
-
-    def _get_xpath_double_quote_str_end(self, start, xpath):
-        idx = start+1 # skip first single quote
-        while idx < len(xpath):
-            if xpath[idx] == '"':
-                break
-            # libyang implements XPATH 1.0 which does not escape double quotes
-            # libyang src: https://netopeer.liberouter.org/doc/libyang/master/html/howtoxpath.html
-            # XPATH 1.0 src: https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Literal
-            idx = idx+1
-
-        return idx
-
-    def create_xpath(self, tokens):
-        """
-        Creates an xpath by combining the given tokens using '/'
-        Example:
-          tokens: module, container, list[key='value'], leaf
-          xpath: /module/container/list[key='value']/leaf
-        """
-        if len(tokens) == 0:
-            return "/"
-
-        return f"{PathAddressing.XPATH_SEPARATOR}{PathAddressing.XPATH_SEPARATOR.join(str(t) for t in tokens)}"
-
     def _create_sonic_yang_with_loaded_models(self):
         return self.config_wrapper.create_sonic_yang_with_loaded_models()
 
-    def find_ref_paths(self, path, config, reload_config=True):
+    def find_ref_paths(self, paths, config, reload_config: bool = True):
         """
         Finds the paths referencing any line under the given 'path' within the given 'config'.
         Example:
@@ -579,42 +500,38 @@ class PathAddressing:
             /ACL_TABLE/EVERFLOW6/ports/1
         """
         # TODO: Also fetch references by must statement (check similar statements)
-        return self._find_leafref_paths(path, config, reload_config=reload_config)
+        sy = self._create_sonic_yang_with_loaded_models()
 
-    def _find_leafref_paths(self, path, config, reload_config=True):
         if reload_config:
             _config_hash = hashlib.md5(
                 json.dumps(config, sort_keys=True).encode()
             ).hexdigest()
             already_loaded = (
                 self.config_wrapper is not None and
-                self.config_wrapper._currently_loaded_hash == _config_hash and
-                self.config_wrapper._loaded_sy is not None
+                self.config_wrapper._currently_loaded_hash == _config_hash
             )
             if not already_loaded:
-                sy = self._create_sonic_yang_with_loaded_models()
                 sy.loadData(config)
                 if self.config_wrapper is not None:
                     self.config_wrapper._currently_loaded_hash = _config_hash
-                    self.config_wrapper._loaded_sy = sy
-            else:
-                sy = self.config_wrapper._loaded_sy
-        else:
-            sy = self._create_sonic_yang_with_loaded_models()
-            sy.loadData(config)
 
-        if not isinstance(path, list):
-            path = [path]
-
-        ref_xpaths = []
-        for inner_path in path:
-            xpath = self.convert_path_to_xpath(inner_path, config, sy)
-            leaf_xpaths = self._get_inner_leaf_xpaths(xpath, sy)
-            for leaf_xpath in leaf_xpaths:
-                ref_xpaths.extend(sy.find_data_dependencies(leaf_xpath))
+        # Force to be a list
+        if not isinstance(paths, list):
+            paths = [paths]
 
         ref_paths = []
         ref_paths_set = set()
+        ref_xpaths = []
+
+        # Iterate across all paths fetching references
+        for path in paths:
+            xpath = self.convert_path_to_xpath(path, config, sy)
+
+            leaf_xpaths = self._get_inner_leaf_xpaths(xpath, sy)
+            for xpath in leaf_xpaths:
+                ref_xpaths.extend(sy.find_data_dependencies(xpath))
+
+        # For each xpath, convert to configdb path
         for ref_xpath in ref_xpaths:
             ref_path = self.convert_xpath_to_path(ref_xpath, config, sy)
             if ref_path not in ref_paths_set:
@@ -640,457 +557,107 @@ class PathAddressing:
         schema = node.schema()
         return ly.LYS_LEAF == schema.nodetype()
 
-    def convert_path_to_xpath(self, path, config, sy):
+    def convert_path_to_xpath(self, path, config=None, sy=None):
         """
         Converts the given JsonPatch path (i.e. JsonPointer) to XPATH.
         Example:
           path: /VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode
           xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/tagging_mode
         """
-        self.convert_xpath_to_path
-        tokens = self.get_path_tokens(path)
-        if len(tokens) == 0:
-            return self.create_xpath(tokens)
+        if sy is None:
+            sy = self._create_sonic_yang_with_loaded_models()
+        return sy.configdb_path_to_xpath(path, configdb=config)
 
-        xpath_tokens = []
-        table = tokens[0]
-
-        cmap = sy.confDbYangMap[table]
-
-        # getting the top level element <module>:<topLevelContainer>
-        xpath_tokens.append(cmap['module']+":"+cmap['topLevelContainer'])
-
-        xpath_tokens.extend(self._get_xpath_tokens_from_container(cmap['container'], 0, tokens, config))
-
-        return self.create_xpath(xpath_tokens)
-
-    def _get_xpath_tokens_from_container(self, model, token_index, path_tokens, config):
-        token = path_tokens[token_index]
-        xpath_tokens = [token]
-
-        if len(path_tokens)-1 == token_index:
-            return xpath_tokens
-
-        # check if the configdb token is referring to a list
-        list_model = self._get_list_model(model, token_index, path_tokens)
-        if list_model:
-            new_xpath_tokens = self._get_xpath_tokens_from_list(list_model, token_index+1, path_tokens, config[path_tokens[token_index]])
-            xpath_tokens.extend(new_xpath_tokens)
-            return xpath_tokens
-
-        # check if it is targetting a child container
-        child_container_model = self._get_model(model.get('container'), path_tokens[token_index+1])
-        if child_container_model:
-            new_xpath_tokens = self._get_xpath_tokens_from_container(child_container_model, token_index+1, path_tokens, config[path_tokens[token_index]])
-            xpath_tokens.extend(new_xpath_tokens)
-            return xpath_tokens
-
-        new_xpath_tokens = self._get_xpath_tokens_from_leaf(model, token_index+1, path_tokens, config[path_tokens[token_index]])
-        xpath_tokens.extend(new_xpath_tokens)
-
-        return xpath_tokens
-
-    def _get_xpath_tokens_from_list(self, model, token_index, path_tokens, config):
-        list_name = model['@name']
-
-        tableKey = path_tokens[token_index]
-        listKeys = model['key']['@value']
-        keyDict = self._extractKey(tableKey, listKeys)
-        keyTokens = [f"[{key}='{keyDict[key]}']" for key in keyDict]
-        item_token = f"{list_name}{''.join(keyTokens)}"
-
-        xpath_tokens = [item_token]
-
-        # if whole list-item is needed i.e. if in the path is not referencing child leaf items
-        # Example:
-        #   path: /VLAN/Vlan1000
-        #   xpath: /sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[name='Vlan1000']
-        if len(path_tokens)-1 == token_index:
-            return xpath_tokens
-
-        type_1_list_model = self._get_type_1_list_model(model)
-        if type_1_list_model:
-            new_xpath_tokens = self._get_xpath_tokens_from_type_1_list(type_1_list_model, token_index+1, path_tokens, config[path_tokens[token_index]])
-            xpath_tokens.extend(new_xpath_tokens)
-            return xpath_tokens
-
-        new_xpath_tokens = self._get_xpath_tokens_from_leaf(model, token_index+1, path_tokens,config[path_tokens[token_index]])
-        xpath_tokens.extend(new_xpath_tokens)
-        return xpath_tokens
-
-    def _get_xpath_tokens_from_type_1_list(self, model, token_index, path_tokens, config):
-        type_1_list_name = model['@name']
-        keyName = model['key']['@value']
-        value = path_tokens[token_index]
-        keyToken = f"[{keyName}='{value}']"
-        itemToken = f"{type_1_list_name}{keyToken}"
-
-        return [itemToken]
-
-    def _get_xpath_tokens_from_leaf(self, model, token_index, path_tokens, config):
-        token = path_tokens[token_index]
-
-        # checking all leaves
-        leaf_model = self._get_model(model.get('leaf'), token)
-        if leaf_model:
-            return [token]
-
-        # checking choice
-        choices = model.get('choice')
-        if choices:
-            for choice in choices:
-                cases = choice['case']
-                for case in cases:
-                    leaf_model = self._get_model(case.get('leaf'), token)
-                    if leaf_model:
-                        return [token]
-
-        # checking leaf-list (i.e. arrays of string, number or bool)
-        leaf_list_model = self._get_model(model.get('leaf-list'), token)
-        if leaf_list_model:
-            # if whole-list is to be returned, just return the token without checking the list items
-            # Example:
-            #   path: /VLAN/Vlan1000/dhcp_servers
-            #   xpath: /sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[name='Vlan1000']/dhcp_servers
-            if len(path_tokens)-1 == token_index:
-                return [token]
-            list_config = config[token]
-            value = list_config[int(path_tokens[token_index+1])]
-            # To get a leaf-list instance with the value 'val'
-            #   /module-name:container/leaf-list[.='val']
-            # Source: Check examples in https://netopeer.liberouter.org/doc/libyang/master/html/howto_x_path.html
-            return [f"{token}[.='{value}']"]
-
-        # checking 'uses' statement
-        if not isinstance(config[token], list): # leaf-list under uses is not supported yet in sonic_yang
-            table = path_tokens[0]
-            uses_leaf_model = self._get_uses_leaf_model(model, table, token)
-            if uses_leaf_model:
-                return [token]
-
-        raise ValueError(f"Path token not found.\n  model: {model}\n  token_index: {token_index}\n  " + \
-                         f"path_tokens: {path_tokens}\n  config: {config}")
-
-    def _extractKey(self, tableKey, keys):
-        keyList = keys.split()
-        # get the value groups
-        value = tableKey.split("|")
-        # match lens
-        if len(keyList) != len(value):
-            raise ValueError("Value not found for {} in {}".format(keys, tableKey))
-        # create the keyDict
-        keyDict = dict()
-        for i in range(len(keyList)):
-            keyDict[keyList[i]] = value[i].strip()
-
-        return keyDict
-
-    def _get_list_model(self, model, token_index, path_tokens):
-        parent_container_name = path_tokens[token_index]
-        clist = model.get('list')
-        # Container contains a single list, just return it
-        # TODO: check if matching also by name is necessary
-        if isinstance(clist, dict):
-            return clist
-
-        if isinstance(clist, list):
-            configdb_values_str = path_tokens[token_index+1]
-            # Format: "value1|value2|value|..."
-            configdb_values = configdb_values_str.split("|")
-            for list_model in clist:
-                yang_keys_str = list_model['key']['@value']
-                # Format: "key1 key2 key3 ..."
-                yang_keys = yang_keys_str.split()
-                # if same number of values and keys, this is the intended list-model
-                # TODO: Match also on types and not only the length of the keys/values
-                if len(yang_keys) == len(configdb_values):
-                    return list_model
-            raise GenericConfigUpdaterError(f"Container {parent_container_name} has multiple lists, "
-                                            f"but none of them match the config_db value {configdb_values_str}")
-
-        return None
-
-    def _get_type_1_list_model(self, model):
-        list_name = model['@name']
-        if list_name not in sonic_yang_ext.Type_1_list_maps_model:
-            return None
-
-        # Type 1 list is expected to have a single inner list model.
-        # No need to check if it is a dictionary of list models.
-        return model.get('list')
-
-    def convert_xpath_to_path(self, xpath, config, sy):
+    def convert_xpath_to_path(self, xpath, config=None, sy=None):
         """
         Converts the given XPATH to JsonPatch path (i.e. JsonPointer).
         Example:
           xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/tagging_mode
           path: /VLAN_MEMBER/Vlan1000|Ethernet8/tagging_mode
         """
-        tokens = self.get_xpath_tokens(xpath)
-        if len(tokens) == 0:
-            return self.create_path([])
+        if sy is None:
+            sy = self._create_sonic_yang_with_loaded_models()
+        return sy.xpath_to_configdb_path(xpath, config)
 
-        if len(tokens) == 1:
-            raise GenericConfigUpdaterError("xpath cannot be just the module-name, there is no mapping to path")
+    def configdb_sort_cmp(self, a, b):
+        # Order first by number of backlinks
+        cmp = a["backlinks"] - b["backlinks"]
+        if cmp != 0:
+            return cmp
 
-        table = tokens[1]
-        cmap = sy.confDbYangMap[table]
+        # Then order (in reverse!) by musts
+        cmp = b["musts"] - a["musts"]
+        if cmp != 0:
+            return cmp
 
-        path_tokens = self._get_path_tokens_from_container(cmap['container'], 1, tokens, config)
-        return self.create_path(path_tokens)
+        # Finally, if we differ by number of separators, a lot of times the
+        # one with fewer separators wins.  Hopefully the 'musts' will catch
+        # this anyhow.
+        cmp = a["nsep"] - b["nsep"]
+        return cmp
 
-    def _get_path_tokens_from_container(self, model, token_index, xpath_tokens, config):
-        token = xpath_tokens[token_index]
-        path_tokens = [token]
-
-        if len(xpath_tokens)-1 == token_index:
-            return path_tokens
-
-        # check child list
-        list_name = xpath_tokens[token_index+1].split("[")[0]
-        list_model = self._get_model(model.get('list'), list_name)
-        if list_model:
-            new_path_tokens = self._get_path_tokens_from_list(list_model, token_index+1, xpath_tokens, config[token])
-            path_tokens.extend(new_path_tokens)
-            return path_tokens
-
-        container_name = xpath_tokens[token_index+1]
-        container_model = self._get_model(model.get('container'), container_name)
-        if container_model:
-            new_path_tokens = self._get_path_tokens_from_container(container_model, token_index+1, xpath_tokens, config[token])
-            path_tokens.extend(new_path_tokens)
-            return path_tokens
-
-        new_path_tokens = self._get_path_tokens_from_leaf(model, token_index+1, xpath_tokens, config[token])
-        path_tokens.extend(new_path_tokens)
-
-        return path_tokens
-
-    def _get_path_tokens_from_list(self, model, token_index, xpath_tokens, config):
-        token = xpath_tokens[token_index]
-        key_dict = self._extract_key_dict(token)
-
-        # If no keys specified return empty tokens, as we are already inside the correct table.
-        # Also note that the list name in SonicYang has no correspondence in ConfigDb and is ignored.
-        # Example where VLAN_MEMBER_LIST has no specific key/value:
-        #   xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST
-        #   path: /VLAN_MEMBER
-        if not(key_dict):
-            return []
-
-        listKeys = model['key']['@value']
-        key_list = listKeys.split()
-
-        if len(key_list) != len(key_dict):
-            raise GenericConfigUpdaterError(f"Keys in configDb not matching keys in SonicYang. ConfigDb keys: {key_dict.keys()}. SonicYang keys: {key_list}")
-
-        values = [key_dict[k] for k in key_list]
-        path_token = '|'.join(values)
-        path_tokens = [path_token]
-
-        if len(xpath_tokens)-1 == token_index:
-            return path_tokens
-
-        next_token = xpath_tokens[token_index+1]
-        # if the target node is a key, then it does not have a correspondene to path.
-        # Just return the current 'key1|key2|..' token as it already refers to the keys
-        # Example where the target node is 'name' which is a key in VLAN_MEMBER_LIST:
-        #   xpath: /sonic-vlan:sonic-vlan/VLAN_MEMBER/VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']/name
-        #   path: /VLAN_MEMBER/Vlan1000|Ethernet8
-        if next_token in key_dict:
-            return path_tokens
-
-        type_1_list_model = self._get_type_1_list_model(model)
-        if type_1_list_model:
-            new_path_tokens = self._get_path_tokens_from_type_1_list(type_1_list_model, token_index+1, xpath_tokens, config[path_token])
-            path_tokens.extend(new_path_tokens)
-            return path_tokens
-
-        new_path_tokens = self._get_path_tokens_from_leaf(model, token_index+1, xpath_tokens, config[path_token])
-        path_tokens.extend(new_path_tokens)
-        return path_tokens
-
-    def _get_path_tokens_from_type_1_list(self, model, token_index, xpath_tokens, config):
-        type_1_inner_list_name = model['@name']
-
-        token = xpath_tokens[token_index]
-        list_tokens = token.split("[", 1) # split once on the first '[', first element will be the inner list name
-        inner_list_name = list_tokens[0]
-
-        if type_1_inner_list_name != inner_list_name:
-            raise GenericConfigUpdaterError(f"Type 1 inner list name '{type_1_inner_list_name}' does match xpath inner list name '{inner_list_name}'.")
-
-        key_dict = self._extract_key_dict(token)
-
-        # If no keys specified return empty tokens, as we are already inside the correct table.
-        # Also note that the type 1 inner list name in SonicYang has no correspondence in ConfigDb and is ignored.
-        # Example where VLAN_MEMBER_LIST has no specific key/value:
-        #   xpath: /sonic-dot1p-tc-map:sonic-dot1p-tc-map/DOT1P_TO_TC_MAP/DOT1P_TO_TC_MAP_LIST[name='Dot1p_to_tc_map1']/DOT1P_TO_TC_MAP
-        #   path: /DOT1P_TO_TC_MAP/Dot1p_to_tc_map1
-        if not(key_dict):
-            return []
-
-        if len(key_dict) > 1:
-            raise GenericConfigUpdaterError(f"Type 1 inner list should have only 1 key in xpath, {len(key_dict)} specified. Key dictionary: {key_dict}")
-
-        keyName = next(iter(key_dict.keys()))
-        value = key_dict[keyName]
-
-        path_tokens = [value]
-
-        # If this is the last xpath token, return the path tokens we have built so far, no need for futher checks
-        # Example:
-        #   xpath: /sonic-dot1p-tc-map:sonic-dot1p-tc-map/DOT1P_TO_TC_MAP/DOT1P_TO_TC_MAP_LIST[name='Dot1p_to_tc_map1']/DOT1P_TO_TC_MAP[dot1p='2']
-        #   path: /DOT1P_TO_TC_MAP/Dot1p_to_tc_map1/2
-        if token_index+1 >= len(xpath_tokens):
-            return path_tokens
-
-        # Checking if the next_token is actually a child leaf of the inner type 1 list, for which case
-        # just ignore the token, and return the already created ConfigDb path pointing to the whole object
-        # Example where the leaf specified is the key:
-        #   xpath: /sonic-dot1p-tc-map:sonic-dot1p-tc-map/DOT1P_TO_TC_MAP/DOT1P_TO_TC_MAP_LIST[name='Dot1p_to_tc_map1']/DOT1P_TO_TC_MAP[dot1p='2']/dot1p
-        #   path: /DOT1P_TO_TC_MAP/Dot1p_to_tc_map1/2
-        # Example where the leaf specified is not the key:
-        #   xpath: /sonic-dot1p-tc-map:sonic-dot1p-tc-map/DOT1P_TO_TC_MAP/DOT1P_TO_TC_MAP_LIST[name='Dot1p_to_tc_map1']/DOT1P_TO_TC_MAP[dot1p='2']/tc
-        #   path: /DOT1P_TO_TC_MAP/Dot1p_to_tc_map1/2
-        next_token = xpath_tokens[token_index+1]
-        leaf_model = self._get_model(model.get('leaf'), next_token)
-        if leaf_model:
-            return path_tokens
-
-        raise GenericConfigUpdaterError(f"Type 1 inner list '{type_1_inner_list_name}' does not have a child leaf named '{next_token}'")
-
-    def _get_path_tokens_from_leaf(self, model, token_index, xpath_tokens, config):
-        token = xpath_tokens[token_index]
-
-        # checking all leaves
-        leaf_model = self._get_model(model.get('leaf'), token)
-        if leaf_model:
-            return [token]
-
-        # checking choices
-        choices = model.get('choice')
-        if choices:
-            for choice in choices:
-                cases = choice['case']
-                for case in cases:
-                    leaf_model = self._get_model(case.get('leaf'), token)
-                    if leaf_model:
-                        return [token]
-
-        # checking leaf-list
-        leaf_list_tokens = token.split("[", 1) # split once on the first '[', a regex is used later to fetch keys/values
-        leaf_list_name = leaf_list_tokens[0]
-        leaf_list_model = self._get_model(model.get('leaf-list'), leaf_list_name)
-        if leaf_list_model:
-            # if whole-list is to be returned, just return the list-name without checking the list items
-            # Example:
-            #   xpath: /sonic-vlan:sonic-vlan/VLAN/VLAN_LIST[name='Vlan1000']/dhcp_servers
-            #   path: /VLAN/Vlan1000/dhcp_servers
-            if len(leaf_list_tokens) == 1:
-                return [leaf_list_name]
-            leaf_list_pattern = "^[^\[]+(?:\[\.='([^']*)'\])?$"
-            leaf_list_regex = re.compile(leaf_list_pattern)
-            match = leaf_list_regex.match(token)
-            # leaf_list_name = match.group(1)
-            leaf_list_value = match.group(1)
-            list_config = config[leaf_list_name]
-            # Workaround for those fields who is defined as leaf-list in YANG model but have string value in config DB
-            # No need to lookup the item index in ConfigDb since the list is represented as a string, return path to string immediately
-            # Example:
-            #   xpath: /sonic-buffer-port-egress-profile-list:sonic-buffer-port-egress-profile-list/BUFFER_PORT_EGRESS_PROFILE_LIST/BUFFER_PORT_EGRESS_PROFILE_LIST_LIST[port='Ethernet9']/profile_list[.='egress_lossy_profile']
-            #   path: /BUFFER_PORT_EGRESS_PROFILE_LIST/Ethernet9/profile_list
-            if isinstance(list_config, str):
-                return [leaf_list_name]
-
-            if not isinstance(list_config, list):
-                raise ValueError(f"list_config is expected to be of type list or string. Found {type(list_config)}.\n  " + \
-                                 f"model: {model}\n  token_index: {token_index}\n  " + \
-                                 f"xpath_tokens: {xpath_tokens}\n  config: {config}")
-
-            list_idx = list_config.index(leaf_list_value)
-            return [leaf_list_name, list_idx]
-
-        # checking 'uses' statement
-        if not isinstance(config[leaf_list_name], list):  # leaf-list under uses is not supported yet in sonic_yang
-            table = xpath_tokens[1]
-            uses_leaf_model = self._get_uses_leaf_model(model, table, token)
-            if uses_leaf_model:
-                return [token]
-
-        raise ValueError(f"Xpath token not found.\n  model: {model}\n  token_index: {token_index}\n  " + \
-                         f"xpath_tokens: {xpath_tokens}\n  config: {config}")
-
-    def _extract_key_dict(self, list_token):
-        # Example: VLAN_MEMBER_LIST[name='Vlan1000'][port='Ethernet8']
-        # the groups would be ('VLAN_MEMBER'), ("[name='Vlan1000'][port='Ethernet8']")
-        table_keys_pattern = "^([^\[]+)(.*)$"
-        text = list_token
-        table_keys_regex = re.compile(table_keys_pattern)
-        match = table_keys_regex.match(text)
-        # list_name = match.group(1)
-        all_key_value = match.group(2)
-
-        # Example: [name='Vlan1000'][port='Ethernet8']
-        # the findall groups would be ('name', 'Vlan1000'), ('port', 'Ethernet8')
-        key_value_pattern = "\[([^=]+)='([^']*)'\]"
-        matches = re.findall(key_value_pattern, all_key_value)
-        key_dict = {}
-        for item in matches:
-            key = item[0]
-            value = item[1]
-            key_dict[key] = value
-
-        return key_dict
-
-    def _get_model(self, model, name):
-        if isinstance(model, dict) and model['@name'] == name:
-            return model
-        if isinstance(model, list):
-            for submodel in model:
-                if submodel['@name'] == name:
-                    return submodel
-
-        return None
-
-    def _get_uses_leaf_model(self, model, table, token):
+    def configdb_sorted_keys_by_backlinks(self, configdb_path: str, configdb: dict, reverse: bool = False,
+                                          configdb_relative: bool = False, sy=None):
         """
-          Getting leaf model in uses model matching the given token.
+        Given a path and a config, iterates across all keys at the path location
+        to look up the number of backlinks per key, then returns the keys sorted
+        by backlinks in acending order by default (set reverse=True to use descending order)
+
+        The configdb is only used to look up the keys at the given path, it is not
+        loaded into the context.  The sort is not performed by actual references
+        to the key in data, but rather the "potential" number of references based
+        on the schema alone.
+
+        If configdb_relative=True then we will use the provided configdb ptr
+        directly instead of using the configdb_path parameter to find the proper
+        position.
         """
-        uses_s = model.get('uses')
-        if not uses_s:
-            return None
 
-        # a model can be a single dict or a list of dictionaries, unify to a list of dictionaries
-        if not isinstance(uses_s, list):
-            uses_s = [uses_s]
+        if sy is None and self.config_wrapper is not None:
+            sy = self._create_sonic_yang_with_loaded_models()
 
-        sy = self._create_sonic_yang_with_loaded_models()
-        # find yang module for current table
-        table_module = sy.confDbYangMap[table]['yangModule']
-        # uses Example: "@name": "bgpcmn:sonic-bgp-cmn"
-        for uses in uses_s:
-            if not isinstance(uses, dict):
-                raise GenericConfigUpdaterError(f"'uses' is expected to be a dictionary found '{type(uses)}'.\n" \
-                                                f"  uses: {uses}\n  model: {model}\n  table: {table}\n  token: {token}")
+        # Traverse configdb to find the right pointer
+        ptr = configdb
+        tokens = self.get_path_tokens(configdb_path)
+        if not configdb_relative:
+            for token in tokens:
+                ptr = ptr[token]
 
-            # Assume ':'  means reference to another module
-            if ':' in uses['@name']:
-                name_parts = uses['@name'].split(':')
-                prefix = name_parts[0].strip()
-                uses_module_name = sy._findYangModuleFromPrefix(prefix, table_module)
-                grouping = name_parts[-1].strip()
+        # Test cases expect non-sorted and config_wrapper isn't set.
+        if self.config_wrapper is None:
+            return [key for key in ptr]
+
+        keys = []
+        # Enumerate all keys and retrieve backlinks, store in a list of dictionaries for sorting
+        for key in ptr:
+            tokens.append(key)
+            path = self.create_path(tokens)
+            try:
+                xpath = sy.configdb_path_to_xpath(path, schema_xpath=True)
+            except KeyError:
+                # Test cases use invalid tables, so we have to handle that even
+                # though it shouldn't be possible in live code as tables without
+                # yang are trimmed
+                keys.append({
+                            "key": key,
+                            "backlinks": 0,
+                            "musts": 0,
+                            "nsep": 0
+                            })
             else:
-                uses_module_name = table_module['@name']
-                grouping = uses['@name']
+                keys.append({
+                            "key": key,
+                            "backlinks": len(sy.find_schema_dependencies(xpath, match_ancestors=True)),
+                            "musts": sy.find_schema_must_count(xpath, match_ancestors=True),
+                            "nsep": str(key).count("|")
+                            })
+            tokens.pop()
 
-            leafs = sy.preProcessedYang['grouping'][uses_module_name][grouping]
+        # Sort list of keys by count
+        keys = sorted(keys, key=cmp_to_key(self.configdb_sort_cmp), reverse=reverse)
 
-            leaf_model = self._get_model(leafs, token)
-            if leaf_model:
-                return leaf_model
-
-        return None
+        # Caller doesn't care about the count, just that the list of keys is ordered
+        return [d['key'] for d in keys]
 
 class TitledLogger(logger.Logger):
     def __init__(self, syslog_identifier, title, verbose, print_all_to_console):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -4,6 +4,7 @@ import jsonpatch
 import sonic_yang
 from collections import deque, OrderedDict
 from enum import Enum
+from typing import Any, IO, List, Optional, Tuple
 from .gu_common import OperationWrapper, OperationType, GenericConfigUpdaterError, \
                        JsonChange, PathAddressing, genericUpdaterLogging
 
@@ -1629,55 +1630,89 @@ class RemoveCreateOnlyDependencyMoveGenerator:
         target_config = diff.target_config # Final config after applying whole patch
         reload_config = True
 
-        processed_tables = set()
         for path in self.create_only_filter.get_paths(current_config):
             tokens = self.path_addressing.get_path_tokens(path)
-            table_to_check, create_only_field = tokens[0], tokens[-1]
+            current_field = self.__fetch_path(current_config, tokens)
+            target_field = self.__fetch_path(target_config, tokens)
 
-            if table_to_check in processed_tables:
-                continue
-            else:
-                processed_tables.add(table_to_check)
-
-            if table_to_check not in current_config:
+            # If field is deleted or created we don't care, we only care when it was
+            # already set and is changing value.
+            if current_field is None or target_field is None or current_field == target_field:
                 continue
 
-            current_members = current_config[table_to_check]
-            if not current_members:
-                continue
+            # Create only filters may reference an exact leaf, but it's really the parent that is the
+            # object we're after.
+            tokens.pop()
 
-            if table_to_check not in target_config:
-                continue
+            # First see if there are any dependents for the exact path
+            for move in self.__remove_dependents(diff, tokens, reload_config=reload_config,
+                                                 remove_parent=False):
+                yield move
 
-            target_members = target_config[table_to_check]
-            if not target_members:
-                continue
+            # No need to reload config after first call
+            reload_config = False
 
-            for member_name in current_members:
-                if member_name not in target_members:
-                    continue
+            yield self.__remove_nonempty(diff, tokens)
 
-                current_field = self._get_create_only_field(
-                    current_config, table_to_check, member_name, create_only_field)
-                target_field = self._get_create_only_field(
-                    target_config, table_to_check, member_name, create_only_field)
+            # If that didn't work, likely the parents of the dependent path needs to be removed.
+            for move in self.__remove_dependents(diff, tokens, reload_config=reload_config,
+                                                 remove_parent=True):
+                yield move
 
-                if current_field == target_field:
-                    continue
+            # Remove self again after removing the parents of dependents
+            # NOTE: When we use the DFS sorter this is irrelevant.  Right now we only use DFS so we don't need it
+            #       as it will be called again after it removed any parent dependents.  Commenting out for now.
+            #
+            # yield self.__remove_nonempty(diff, tokens)
 
-                member_path = f"/{table_to_check}/{member_name}"
+    def __fetch_path(self, config, tokens: List[str]) -> Any:
+        for token in tokens:
+            config = config.get(token)
+            if config is None:
+                return None
+        return config
 
-                for ref_path in self.path_addressing.find_ref_paths(member_path, current_config,
-                                                                    reload_config=reload_config):
-                    yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE,
-                                        self.path_addressing.get_path_tokens(ref_path)))
+    def __get_path_count(self, config, tokens: List[str]) -> int:
+        config = self.__fetch_path(config, tokens)
+        if config is None:
+            return 0
+        return len(config)
 
-                # No need to reload config after first call
-                reload_config = False
+    def __remove_nonempty(self, diff: Diff, tokens: List[str]):
+        remove_tokens = list(tokens)
+        # Only trim while there is at least one table token and one deeper level.
+        # This prevents generating an empty path ("") and avoids an infinite loop
+        # when the top-level config has a single table.
+        while len(remove_tokens) > 1 and \
+                self.__get_path_count(diff.current_config, remove_tokens[:-1]) == 1:
+            remove_tokens = remove_tokens[:-1]
+        return JsonMoveGroup(JsonMove(diff, OperationType.REMOVE, remove_tokens))
 
-    def _get_create_only_field(self, config, table_to_check,
-                               member_name, create_only_field):
-        return config[table_to_check][member_name].get(create_only_field, None)
+    def __remove_dependents(
+        self,
+        diff: Diff,
+        tokens: List[str],
+        reload_config: bool,
+        remove_parent: bool,
+        recursion_depth: int = 0,
+    ):
+        if recursion_depth >= 10:
+            return
+
+        config = diff.current_config
+        path = self.path_addressing.create_path(tokens)
+        ref_paths = self.path_addressing.find_ref_paths(path, config, reload_config)
+        for ref in ref_paths:
+            ref_tokens = self.path_addressing.get_path_tokens(ref)
+            if remove_parent:
+                ref_tokens.pop()
+
+            # Recurse since there could be a dependency chain
+            for move in self.__remove_dependents(diff, ref_tokens, reload_config=False,
+                                                 remove_parent=remove_parent, recursion_depth=recursion_depth+1):
+                yield move
+
+            yield self.__remove_nonempty(diff, ref_tokens)
 
 
 class LowLevelMoveGenerator:
@@ -2165,12 +2200,10 @@ class SortAlgorithmFactory:
         self.config_wrapper = config_wrapper
         self.path_addressing = path_addressing
 
-    def create(self, algorithm=Algorithm.DFS):
-        move_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
-                           LowLevelMoveGenerator(self.path_addressing)]
+    def create(self, algorithm=Algorithm.DFS, path_trace: bool = False):
+        move_generators = [LowLevelMoveGenerator(self.path_addressing)]
         # TODO: Enable TableLevelMoveGenerator once it is confirmed whole table can be updated at the same time
         move_non_extendable_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
-                                          BulkLeafListMoveGenerator(self.path_addressing),
                                           BulkKeyLevelMoveGenerator(self.path_addressing),
                                           KeyLevelMoveGenerator(self.path_addressing),
                                           BulkKeyGroupLowLevelMoveGenerator(self.path_addressing),

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -743,6 +743,7 @@ class RemoveCreateOnlyDependencyMoveValidator:
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing
         self.create_only_filter = CreateOnlyFilter(path_addressing).get_filter()
+        self.logger = genericUpdaterLogging.get_logger(title="Patch Sorter - RemoveCreateOnly")
 
     def validate(self, group: JsonMoveGroup, diff, simulated_config):
         # Note: group is not used by this validator
@@ -817,7 +818,28 @@ class RemoveCreateOnlyDependencyMoveValidator:
                 return False
 
         member_path = f"/{table_to_check}/{member_name}"
-        for ref_path in self.path_addressing.find_ref_paths(member_path, simulated_config, reload_config=reload_config):
+        try:
+            ref_paths = self.path_addressing.find_ref_paths(
+                member_path, simulated_config, reload_config=reload_config)
+        except (ValueError, KeyError) as e:
+            # An unresolvable or malformed reference against the simulated intermediate config
+            # raises here. The motivating case: a create-only field change (e.g. a PORT breakout
+            # that rewrites lanes) has transiently removed this member from a multi-member leaf-list
+            # (e.g. ACL_TABLE.ports) while a leafref to it is still present, so the dangling leafref
+            # fails to resolve (list.index raises ValueError). Other resolution failures in the
+            # xpath<->configdb-path conversion (schema/key-count mismatches raise ValueError; a table
+            # with no YANG model raises KeyError) likewise indicate the reference cannot be resolved
+            # against this intermediate config. In every case the ordering is an invalid intermediate
+            # move, so reject it and let the sort backtrack rather than aborting the whole sort.
+            # Scope is deliberately limited to reference-resolution errors: a loadData failure
+            # (sonic_yang.SonicYangException) is not caught here because FullConfigMoveValidator has
+            # already loaded this config into the sy singleton, so find_ref_paths skips loadData.
+            self.logger.log_debug(
+                f"Rejecting move: reference resolution failed against simulated config "
+                f"for '{member_path}': {type(e).__name__}: {e}")
+            return False
+
+        for ref_path in ref_paths:
             if not self.path_addressing.has_path(current_config, ref_path):
                 return False
 
@@ -958,6 +980,7 @@ class NoDependencyMoveValidator:
     def __init__(self, path_addressing, config_wrapper):
         self.path_addressing = path_addressing
         self.config_wrapper = config_wrapper
+        self.logger = genericUpdaterLogging.get_logger(title="Patch Sorter - NoDependency")
 
     def validate(self, group: JsonMoveGroup, diff, simulated_config):
         reload_config = True
@@ -974,7 +997,8 @@ class NoDependencyMoveValidator:
 
         if operation_type == OperationType.ADD:
             # For add operation, we check the simulated config has no dependencies between nodes under the added path
-            if not self._validate_paths_config([path], simulated_config, reload_config):
+            if not self._validate_paths_config([path], simulated_config, reload_config,
+                                               reject_on_unresolvable_ref=True):
                 return False
         elif operation_type == OperationType.REMOVE:
             # For remove operation, we check the current config has no dependencies between nodes under the removed path
@@ -1025,7 +1049,8 @@ class NoDependencyMoveValidator:
         # so _currently_loaded_hash will match and find_ref_paths skips loadData.
         # Then validate deleted_paths against current_config (requires a fresh loadData).
         # This ordering gives 2 loadData calls instead of 3 for REPLACE operations.
-        if not self._validate_paths_config(added_paths, simulated_config, reload_config=True):
+        if not self._validate_paths_config(added_paths, simulated_config, reload_config=True,
+                                           reject_on_unresolvable_ref=True):
             return False
 
         if not self._validate_paths_config(deleted_paths, diff.current_config, reload_config=True):
@@ -1095,11 +1120,31 @@ class NoDependencyMoveValidator:
 
         return deleted_paths, added_paths
 
-    def _validate_paths_config(self, paths, config, reload_config: bool = True):
+    def _validate_paths_config(self, paths, config, reload_config: bool = True,
+                               reject_on_unresolvable_ref: bool = False):
         """
         validates all config under paths do not have config and its references
+
+        reject_on_unresolvable_ref: set only when 'config' is the transient simulated intermediate
+        state. A dangling leafref in that state (e.g. a create-only PORT change that has transiently
+        removed the port from a leaf-list such as ACL_TABLE.ports while a reference to it lingers)
+        makes find_ref_paths raise ValueError; a table with no YANG model makes it raise KeyError.
+        Either way it is an invalid intermediate move, so reject it and let the sort backtrack rather
+        than aborting. When 'config' is diff.current_config (a valid committed state) the flag stays
+        False: such an error there is genuine and must surface instead of being silently swallowed.
+        Scope is limited to reference-resolution errors; a loadData failure
+        (sonic_yang.SonicYangException) is not caught because the config is already loaded into the sy
+        singleton by FullConfigMoveValidator, so find_ref_paths skips loadData for it.
         """
-        refs = self.path_addressing.find_ref_paths(paths, config, reload_config=reload_config)
+        try:
+            refs = self.path_addressing.find_ref_paths(paths, config, reload_config=reload_config)
+        except (ValueError, KeyError) as e:
+            if reject_on_unresolvable_ref:
+                self.logger.log_debug(
+                    f"Rejecting move: reference resolution failed against simulated config "
+                    f"for {paths}: {type(e).__name__}: {e}")
+                return False
+            raise
         for ref in refs:
             for path in paths:
                 if ref.startswith(path):

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import jsonpatch
+import sonic_yang
 from collections import deque, OrderedDict
 from enum import Enum
 from .gu_common import OperationWrapper, OperationType, GenericConfigUpdaterError, \
@@ -29,8 +30,12 @@ class Diff:
     # TODO: Can be optimized to apply the move in place. JsonPatch supports that using the option 'in_place=True'
     # Check: https://python-json-patch.readthedocs.io/en/latest/tutorial.html#applying-a-patch
     # NOTE: in case move is applied in place, we will need to support `undo_move` as well.
-    def apply_move(self, move):
-        new_current_config = move.apply(self.current_config)
+    def apply_move(self, move, in_place: bool = False):
+        new_current_config = move.apply(self.current_config, in_place)
+        return Diff(new_current_config, self.target_config)
+
+    def undo_move(self, move, in_place: bool = False):
+        new_current_config = move.undo(self.current_config, in_place)
         return Diff(new_current_config, self.target_config)
 
     def has_no_diff(self):
@@ -42,6 +47,7 @@ target_config: {self.target_config}"""
 
     def __repr__(self):
         return str(self)
+
 
 class JsonMove:
     """
@@ -58,7 +64,10 @@ class JsonMove:
     and current_config_tokens i.e. current_config path where the update needs to happen.
     """
     def __init__(self, diff, op_type, current_config_tokens, target_config_tokens=None):
-        operation = JsonMove._to_jsonpatch_operation(diff, op_type, current_config_tokens, target_config_tokens)
+        # Support for undo
+        self.orig_value = None
+
+        operation = self._to_jsonpatch_operation(diff, op_type, current_config_tokens, target_config_tokens)
         self.patch = jsonpatch.JsonPatch([operation])
         self.op_type = operation[OperationWrapper.OP_KEYWORD]
         self.path = operation[OperationWrapper.PATH_KEYWORD]
@@ -68,8 +77,7 @@ class JsonMove:
         self.current_config_tokens = current_config_tokens
         self.target_config_tokens = target_config_tokens
 
-    @staticmethod
-    def _to_jsonpatch_operation(diff, op_type, current_config_tokens, target_config_tokens):
+    def _to_jsonpatch_operation(self, diff, op_type, current_config_tokens, target_config_tokens):
         operation_wrapper = OperationWrapper()
         path_addressing = PathAddressing()
 
@@ -90,8 +98,9 @@ class JsonMove:
     @staticmethod
     def _get_value(config, tokens):
         for token in tokens:
+            if isinstance(config, list):
+                token = int(token)
             config = config[token]
-
         return copy.deepcopy(config)
 
     @staticmethod
@@ -271,8 +280,26 @@ class JsonMove:
 
         return JsonMove(diff, op_type, current_config_tokens, target_config_tokens)
 
-    def apply(self, config):
-        return self.patch.apply(config)
+    def apply(self, config, in_place: bool = False):
+        if self.op_type == OperationType.REMOVE or self.op_type == OperationType.REPLACE:
+            self.orig_value = JsonMove._get_value(config, sonic_yang.SonicYang.configdb_path_split(self.path))
+
+        return self.patch.apply(config, in_place=in_place)
+
+    def undo(self, config, in_place: bool = False):
+        # Create new patch to undo previous application
+        if self.patch.patch[0]['op'] == 'add':
+            patch = jsonpatch.JsonPatch([{'op': 'remove', 'path': self.patch.patch[0]['path']}])
+        elif self.patch.patch[0]['op'] == 'replace':
+            patch = jsonpatch.JsonPatch([{
+                                        'op': 'replace',
+                                        'path': self.patch.patch[0]['path'],
+                                        'value': self.orig_value
+                                        }])
+        elif self.patch.patch[0]['op'] == 'remove':
+            patch = jsonpatch.JsonPatch([{'op': 'add', 'path': self.patch.patch[0]['path'], 'value': self.orig_value}])
+
+        return patch.apply(config, in_place=in_place)
 
     def __str__(self):
         return str(self.patch)
@@ -288,6 +315,107 @@ class JsonMove:
 
     def __hash__(self):
         return hash((self.op_type, self.path, json.dumps(self.value)))
+
+
+class JsonMoveGroup:
+    """
+    Group of JsonMove objects to be applied together
+    """
+    def __init__(self, move: JsonMove = None):
+        self.patches = []
+        if move is not None:
+            self.append(move)
+
+    def append(self, move: JsonMove):
+        self.patches.append(move)
+
+    def apply(self, config, in_place: bool = False):
+        update = config
+        for i, patch in enumerate(self.patches):
+            if i != 0:
+                in_place = True
+            update = patch.apply(update, in_place=in_place)
+            if update is None:
+                return None
+        return update
+
+    def undo(self, config, in_place: bool = False):
+        update = config
+        for i, patch in enumerate(reversed(self.patches)):
+            if i != 0:
+                in_place = True
+            update = patch.undo(update, in_place=in_place)
+            if update is None:
+                return None
+        return update
+
+    def get_jsonpatch(self):
+        raw_patches = []
+        for move in self.patches:
+            raw_patches.extend(move.patch.patch)
+        return jsonpatch.JsonPatch(raw_patches)
+
+    def parentTableName(self):
+        """
+        This extracts the parent table name from the first patch associated
+        with this grouping.  This is a bit special-cased for grouping purposes
+        where it evaluates both '/' and '|' to look for parents to group.
+
+        Examples:
+         * /PORT/Ethernet0/description -> /PORT
+         * /PORTCHANNEL_MEMBER/PortChannel0001|Ethernet16 -> /PORTCHANNEL_MEMBER/PortChannel0001
+         * /ACL_RULE/V4-ACL-TABLE|Rule_20/DST_IP -> /ACL_RULE/V4-ACL-TABLE
+        """
+        tokens = sonic_yang.SonicYang.configdb_path_split(self.patches[0].path)
+
+        # See if the last token has a |, if so just truncate and return
+        token = tokens[-1]
+        if "|" in token:
+            tokens[-1] = token.rsplit("|", 1)[0]
+            return sonic_yang.SonicYang.configdb_path_join(tokens)
+
+        # Pop off the last element as we don't need it, its not a key
+        tokens.pop()
+
+        # See if the last token has a |, if so just truncate and return
+        token = tokens[-1]
+        if "|" in token:
+            tokens[-1] = token.rsplit("|", 1)[0]
+            return sonic_yang.SonicYang.configdb_path_join(tokens)
+
+        # If we're here it means we're on a key to be removed, pop and return
+        tokens.pop()
+        return sonic_yang.SonicYang.configdb_path_join(tokens)
+
+    def merge(self, group):
+        self.patches.extend(group.patches)
+
+    def __str__(self):
+        return ",".join([str(patch) for patch in self.patches])
+
+    def __repr__(self):
+        return str(self)
+
+    def __eq__(self, other):
+        if isinstance(other, JsonMoveGroup):
+            if len(other) != len(self.patches):
+                return False
+            for i, patch in enumerate(self.patches):
+                if patch.patch != other.patches[i].patch:
+                    return False
+            return True
+        return False
+
+    def __hash__(self):
+        return hash(str(self))
+
+    def __len__(self):
+        return len(self.patches)
+
+    def __iter__(self):
+        for patch in self.patches:
+            yield patch
+
 
 class MoveWrapper:
     def __init__(self, move_generators, move_non_extendable_generators, move_extenders, move_validators):
@@ -312,7 +440,6 @@ class MoveWrapper:
         processed_moves = set()
         extended_moves = set()
         moves = deque([])
-
         for move in self._generate_non_extendable_moves(diff):
             if not(move in processed_moves):
                 processed_moves.add(move)
@@ -338,13 +465,19 @@ class MoveWrapper:
                 moves.extend(self._extend_moves(move, diff))
 
     def validate(self, move, diff):
+        # Generate simulated config once, not once per validator as this performs
+        # a deep copy
+        simulated_config = move.apply(diff.current_config)
         for validator in self.move_validators:
-            if not validator.validate(move, diff):
+            if not validator.validate(move, diff, simulated_config):
                 return False
         return True
 
-    def simulate(self, move, diff):
-        return diff.apply_move(move)
+    def simulate(self, move, diff, in_place: bool = False):
+        return diff.apply_move(move, in_place)
+
+    def undo_simulate(self, move, diff, in_place: bool = False):
+        return diff.undo_move(move, in_place)
 
     def _generate_moves(self, diff):
         for generator in self.move_generators:
@@ -356,10 +489,14 @@ class MoveWrapper:
             for move in generator.generate(diff):
                 yield move
 
-    def _extend_moves(self, move, diff):
-        for extender in self.move_extenders:
-            for newmove in extender.extend(move, diff):
-                yield newmove
+    def _extend_moves(self, moveGroup: JsonMoveGroup, diff) -> JsonMoveGroup:
+        # The enxtender only operates on JsonMove, so iterate across the individual
+        # moves within the group to generate the new moves.  In theory there
+        # should be at most one move per group if we're running extenders.
+        for move in moveGroup:
+            for extender in self.move_extenders:
+                for newmove in extender.extend(move, diff):
+                    yield JsonMoveGroup(newmove)
 
 class JsonPointerFilter:
     """
@@ -493,6 +630,26 @@ class RequiredValueIdentifier:
                     setting["common_key_index"] = index
             setting["requiring_filter"] = JsonPointerFilter(setting["requiring_patterns"], path_addressing)
 
+    """
+    Simple function to determine if the path tokens match any of the required patterns.
+    This is used to avoid grouping such changes in bulk operations.
+    """
+    def target_in_required_pattern(self, configdb_path_tokens):
+        for setting in self.settings:
+            if len(setting["required_pattern"]) != len(configdb_path_tokens):
+                continue
+
+            is_match = True
+
+            for idx, token in enumerate(setting["required_pattern"]):
+                if token not in ["*", "@", configdb_path_tokens[idx]]:
+                    is_match = False
+                    break
+
+            if is_match:
+                return True
+
+        return False
 
     def get_required_value_data(self, configs):
         data = {}
@@ -586,9 +743,11 @@ class RemoveCreateOnlyDependencyMoveValidator:
         self.path_addressing = path_addressing
         self.create_only_filter = CreateOnlyFilter(path_addressing).get_filter()
 
-    def validate(self, move, diff):
+    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+        # Note: group is not used by this validator
         current_config = diff.current_config
         target_config = diff.target_config # Final config after applying whole patch
+        reload_config = True
 
         processed_tables = set()
         for path in self.create_only_filter.get_paths(current_config):
@@ -614,19 +773,22 @@ class RemoveCreateOnlyDependencyMoveValidator:
             if not target_members:
                 continue
 
-            simulated_config = move.apply(current_config) # Config after applying just this move
-
             for member_name in current_members:
                 if member_name not in target_members:
                     continue
 
                 if not self._validate_member(tokens, member_name,
-                                             current_config, target_config, simulated_config):
+                                             current_config, target_config, simulated_config,
+                                             reload_config=reload_config):
                     return False
+
+                # After first call, no need to reload again
+                reload_config = False
 
         return True
 
-    def _validate_member(self, tokens, member_name, current_config, target_config, simulated_config):
+    def _validate_member(self, tokens, member_name, current_config, target_config, simulated_config,
+                         reload_config: bool = True):
         table_to_check, create_only_field = tokens[0], tokens[-1]
 
         current_field = self._get_create_only_field(
@@ -654,7 +816,7 @@ class RemoveCreateOnlyDependencyMoveValidator:
                 return False
 
         member_path = f"/{table_to_check}/{member_name}"
-        for ref_path in self.path_addressing.find_ref_paths(member_path, simulated_config):
+        for ref_path in self.path_addressing.find_ref_paths(member_path, simulated_config, reload_config=reload_config):
             if not self.path_addressing.has_path(current_config, ref_path):
                 return False
 
@@ -668,8 +830,8 @@ class DeleteWholeConfigMoveValidator:
     """
     A class to validate not deleting whole config as it is not supported by JsonPatch lib.
     """
-    def validate(self, move, diff):
-        if move.op_type == OperationType.REMOVE and move.path == "":
+    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+        if group.patches[0].op_type == OperationType.REMOVE and group.patches[0].path == "":
             return False
         return True
 
@@ -680,8 +842,7 @@ class FullConfigMoveValidator:
     def __init__(self, config_wrapper):
         self.config_wrapper = config_wrapper
 
-    def validate(self, move, diff):
-        simulated_config = move.apply(diff.current_config)
+    def validate(self, move, diff, simulated_config):
         is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
         return is_valid
 
@@ -698,8 +859,9 @@ class CreateOnlyMoveValidator:
         # TODO: create-only fields are hard-coded for now, it should be moved to YANG models
         self.create_only_filter = CreateOnlyFilter(path_addressing).get_filter()
 
-    def validate(self, move, diff):
-        simulated_config = move.apply(diff.current_config)
+    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+        # NOTE: group not used by this validator
+
         # get create-only paths from current config, simulated config and also target config
         # simulated config is the result of the move
         # target config is the final config
@@ -796,27 +958,35 @@ class NoDependencyMoveValidator:
         self.path_addressing = path_addressing
         self.config_wrapper = config_wrapper
 
-    def validate(self, move, diff):
+    def validate(self, group: JsonMoveGroup, diff, simulated_config):
+        reload_config = True
+        # Note: all moves in a group are guaranteed to be the same operation type
+        for move in group:
+            if not self.__validate_move(move, diff, simulated_config, reload_config=reload_config):
+                return False
+            reload_config = False
+        return True
+
+    def __validate_move(self, move, diff, simulated_config, reload_config: bool = True):
         operation_type = move.op_type
         path = move.path
 
         if operation_type == OperationType.ADD:
-            simulated_config = move.apply(diff.current_config)
             # For add operation, we check the simulated config has no dependencies between nodes under the added path
-            if not self._validate_paths_config([path], simulated_config):
+            if not self._validate_paths_config([path], simulated_config, reload_config):
                 return False
         elif operation_type == OperationType.REMOVE:
             # For remove operation, we check the current config has no dependencies between nodes under the removed path
-            if not self._validate_paths_config([path], diff.current_config):
+            if not self._validate_paths_config([path], diff.current_config, reload_config):
                 return False
         elif operation_type == OperationType.REPLACE:
-            if not self._validate_replace(move, diff):
+            if not self._validate_replace(move, diff, simulated_config):
                 return False
 
         return True
 
     # NOTE: this function can be used for validating JsonChange as well which might have more than one move.
-    def _validate_replace(self, move, diff):
+    def _validate_replace(self, move, diff, simulated_config):
         """
         The table below shows how mixed deletion/addition within replace affect this validation.
 
@@ -847,15 +1017,17 @@ class NoDependencyMoveValidator:
         if A is added and refA is added: return False
         return True
         """
-        simulated_config = move.apply(diff.current_config)
         deleted_paths, added_paths = self._get_paths(diff.current_config, simulated_config, [])
 
-        # For added paths, we check the simulated config has no dependencies between nodes under the added path
-        if not self._validate_paths_config(added_paths, simulated_config):
+        # Validate added_paths against simulated_config first: FullConfigMoveValidator has
+        # already loaded simulated_config into the sy singleton (via validate_config_db_config),
+        # so _currently_loaded_hash will match and find_ref_paths skips loadData.
+        # Then validate deleted_paths against current_config (requires a fresh loadData).
+        # This ordering gives 2 loadData calls instead of 3 for REPLACE operations.
+        if not self._validate_paths_config(added_paths, simulated_config, reload_config=True):
             return False
 
-        # For deleted paths, we check the current config has no dependencies between nodes under the removed path
-        if not self._validate_paths_config(deleted_paths, diff.current_config):
+        if not self._validate_paths_config(deleted_paths, diff.current_config, reload_config=True):
             return False
 
         return True
@@ -922,20 +1094,17 @@ class NoDependencyMoveValidator:
 
         return deleted_paths, added_paths
 
-    def _validate_paths_config(self, paths, config):
+    def _validate_paths_config(self, paths, config, reload_config: bool = True):
         """
         validates all config under paths do not have config and its references
         """
-        refs = self._find_ref_paths(paths, config)
+        refs = self.path_addressing.find_ref_paths(paths, config, reload_config=reload_config)
         for ref in refs:
             for path in paths:
                 if ref.startswith(path):
                     return False
 
         return True
-
-    def _find_ref_paths(self, paths, config):
-        return self.path_addressing.find_ref_paths(paths, config)
 
 class NoEmptyTableMoveValidator:
     """
@@ -944,8 +1113,13 @@ class NoEmptyTableMoveValidator:
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing
 
-    def validate(self, move, diff):
-        simulated_config = move.apply(diff.current_config)
+    def validate(self, group, diff, simulated_config):
+        for move in group:
+            if not self.__validate_move(move, diff, simulated_config):
+                return False
+        return True
+
+    def __validate_move(self, move, diff, simulated_config):
         op_path = move.path
 
         if op_path == "": # If updating whole file
@@ -981,13 +1155,12 @@ class RequiredValueMoveValidator:
         self.path_addressing = path_addressing
         self.identifier = RequiredValueIdentifier(path_addressing)
 
-    def validate(self, move, diff):
+    def validate(self, group: JsonMoveGroup, diff, simulated_config):
         # ignore full config removal because it is not possible by JsonPatch lib
-        if move.op_type == OperationType.REMOVE and move.path == "":
+        if group.patches[0].op_type == OperationType.REMOVE and group.patches[0].path == "":
             return
 
         current_config = diff.current_config
-        simulated_config = move.apply(current_config) # Config after applying just this move
         target_config = diff.target_config # Final config after applying whole patch
 
         # data dictionary:
@@ -1037,57 +1210,22 @@ class TableLevelMoveGenerator:
     This class will generate moves to remove tables if they are in current, but not target. It also add tables
     if they are in target but not current configs.
     """
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
 
     def generate(self, diff):
         # Removing tables in current but not target
-        for tokens in self._get_non_existing_tables_tokens(diff.current_config, diff.target_config):
-            yield JsonMove(diff, OperationType.REMOVE, tokens)
+        for tokens in self._get_non_existing_tables_tokens(diff.current_config, diff.target_config, False):
+            yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE, tokens))
 
         # Adding tables in target but not current
-        for tokens in self._get_non_existing_tables_tokens(diff.target_config, diff.current_config):
-            yield JsonMove(diff, OperationType.ADD, tokens, tokens)
+        for tokens in self._get_non_existing_tables_tokens(diff.target_config, diff.current_config, True):
+            yield JsonMoveGroup(JsonMove(diff, OperationType.ADD, tokens, tokens))
 
-    def _get_non_existing_tables_tokens(self, config1, config2):
-        for table in config1:
+    def _get_non_existing_tables_tokens(self, config1, config2, reverse):
+        for table in self.path_addressing.configdb_sorted_keys_by_backlinks("/", config1, reverse=reverse):
             if not(table in config2):
                 yield [table]
-
-
-class BulkLeafListMoveGenerator:
-    """
-    A class that generates bulk REPLACE moves for leaf-lists (lists of primitive
-    values) that differ between current and target configs.
-    """
-    def generate(self, diff):
-        for move in self._traverse(diff, diff.current_config, diff.target_config, []):
-            yield move
-
-    def _traverse(self, diff, current_ptr, target_ptr, tokens):
-        if not isinstance(current_ptr, dict) or not isinstance(target_ptr, dict):
-            return
-
-        for key in current_ptr:
-            if key not in target_ptr:
-                continue
-
-            current_val = current_ptr[key]
-            target_val = target_ptr[key]
-            tokens.append(key)
-
-            if isinstance(current_val, list) and isinstance(target_val, list):
-                if (current_val != target_val and
-                        self._is_leaf_list(current_val) and
-                        self._is_leaf_list(target_val)):
-                    yield JsonMove(diff, OperationType.REPLACE, list(tokens), list(tokens))
-            elif isinstance(current_val, dict) and isinstance(target_val, dict):
-                for move in self._traverse(diff, current_val, target_val, tokens):
-                    yield move
-
-            tokens.pop()
-
-    @staticmethod
-    def _is_leaf_list(lst):
-        return all(isinstance(item, (str, int, float, bool)) for item in lst)
 
 class KeyLevelMoveGenerator:
     """
@@ -1104,38 +1242,379 @@ class KeyLevelMoveGenerator:
     This class will generate moves to remove keys if they are in current, but not target. It also add keys
     if they are in target but not current configs.
     """
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+
     def generate(self, diff):
         # Removing keys in current but not target
-        for tokens in self._get_non_existing_keys_tokens(diff.current_config, diff.target_config):
+        for tokens in self._get_non_existing_keys_tokens(diff.current_config, diff.target_config, reverse=False):
             table = tokens[0]
             # if table has a single key, delete the whole table because empty tables are not allowed in ConfigDB
-            # BUT only if the table won't exist in target config (i.e., not adding new keys to it)
-            if len(diff.current_config[table]) == 1 and table not in diff.target_config:
-                yield JsonMove(diff, OperationType.REMOVE, [table])
+            if len(diff.current_config[table]) == 1:
+                yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE, [table]))
             else:
-                yield JsonMove(diff, OperationType.REMOVE, tokens)
+                yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE, tokens))
 
         # Adding keys in target but not current
-        for tokens in self._get_non_existing_keys_tokens(diff.target_config, diff.current_config):
-            yield JsonMove(diff, OperationType.ADD, tokens, tokens)
+        for tokens in self._get_non_existing_keys_tokens(diff.target_config, diff.current_config, reverse=True):
+            yield JsonMoveGroup(JsonMove(diff, OperationType.ADD, tokens, tokens))
 
-    def _get_non_existing_keys_tokens(self, config1, config2):
-        for table in config1:
-            for key in config1[table]:
+    def _get_non_existing_keys_tokens(self, config1, config2, reverse):
+        for table in self.path_addressing.configdb_sorted_keys_by_backlinks("/", config1, reverse=reverse):
+            for key in self.path_addressing.configdb_sorted_keys_by_backlinks("/" + table, config1, reverse=reverse):
                 if not(table in config2) or not (key in config2[table]):
                     yield [table, key]
 
-class LowLevelMoveGenerator:
+
+class BulkLeafListMoveGenerator:
     """
-    A class to generate the low level moves i.e. moves corresponding to differences between current/target config
-    where the path of the move does not have children.
+    A non-extendable generator that produces a single REPLACE move for each
+    leaf-list field whose items differ between current and target configs.
+
+    Instead of generating N individual REMOVE/ADD moves (one per list item),
+    this emits one REPLACE of the whole list. The DFS tries non-extendable
+    generators first, so if the bulk replace validates, we skip N-1 moves
+    and their associated loadData() calls.
+
+    This is conservative:
+    - Only handles leaf-lists (lists of scalars, not lists of dicts)
+    - Only replaces lists that already exist in both current and target
+    - If this move fails validation, DFS continues to other generators
+      which produce per-item moves (no explicit fallback mechanism)
     """
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing
+
     def generate(self, diff):
-        single_run_generator = SingleRunLowLevelMoveGenerator(diff, self.path_addressing)
-        for move in single_run_generator.generate():
+        for move in self._traverse(diff, diff.current_config, diff.target_config, []):
             yield move
+
+    def _traverse(self, diff, current_ptr, target_ptr, tokens):
+        if not isinstance(current_ptr, dict) or not isinstance(target_ptr, dict):
+            return
+
+        for key in current_ptr:
+            if key not in target_ptr:
+                continue
+
+            tokens.append(key)
+            current_val = current_ptr[key]
+            target_val = target_ptr[key]
+
+            if isinstance(current_val, list) and isinstance(target_val, list):
+                # Only handle leaf-lists (lists of scalars)
+                if (current_val != target_val and
+                        self._is_leaf_list(current_val) and
+                        self._is_leaf_list(target_val)):
+                    yield JsonMoveGroup(
+                        JsonMove(diff, OperationType.REPLACE, list(tokens), list(tokens)),
+                    )
+            elif isinstance(current_val, dict) and isinstance(target_val, dict):
+                for move in self._traverse(diff, current_val, target_val, tokens):
+                    yield move
+
+            tokens.pop()
+
+    @staticmethod
+    def _is_leaf_list(lst):
+        """Return True if lst contains only scalars (str, int, float, bool)."""
+        return all(isinstance(item, (str, int, float, bool)) for item in lst)
+
+
+class BulkKeyLevelMoveGenerator:
+    """
+    Same concept as KeyLevelMoveGenerator, but groups additions and removals of sibling keys.
+    """
+    def __init__(self, path_addressing):
+        self.path_addressing = path_addressing
+
+    def generate(self, diff):
+        prev_num_separators = -1
+        group = None
+        prev_table = ""
+
+        # Removing keys in current but not target
+        for tokens in self._get_non_existing_keys_tokens(diff.current_config, diff.target_config, reverse=False):
+            table = tokens[0]
+            key = tokens[1]
+
+            # If the number of separators changed, do not group these operations with the previous ones.
+            num_separators = key.count("|")
+            if group is not None and (prev_num_separators != num_separators or table != prev_table):
+                # Special case if we are deleting all the current keys in a table to emit a table delete too
+                if len(list(group)) == len(diff.current_config[table if prev_table == "" else prev_table]):
+                    group.append(JsonMove(diff, OperationType.REMOVE, [table]))
+                yield group
+                group = None
+
+            prev_table = table
+            prev_num_separators = num_separators
+            if group is None:
+                group = JsonMoveGroup()
+
+            group.append(JsonMove(diff, OperationType.REMOVE, tokens))
+
+        # Pending group, emit
+        if group is not None:
+            # Special case if we are deleting all the current keys in a table to emit a table delete too
+            if len(list(group)) == len(diff.current_config[table]):
+                group.append(JsonMove(diff, OperationType.REMOVE, [table]))
+            yield group
+
+        prev_num_separators = -1
+        group = None
+        prev_table = ""
+
+        # Adding keys in target but not current
+        for tokens in self._get_non_existing_keys_tokens(diff.target_config, diff.current_config, reverse=True):
+            table = tokens[0]
+            key = tokens[1]
+
+            # We do not support adding the whole table, only grouping key entry creation.
+            if table not in diff.current_config:
+                continue
+
+            # If the number of separators changed, do not group these operations with the previous ones.
+            num_separators = key.count("|")
+            if group is not None and (prev_num_separators != num_separators or table != prev_table):
+                yield group
+                group = None
+
+            prev_table = table
+            prev_num_separators = num_separators
+            if group is None:
+                group = JsonMoveGroup()
+
+            group.append(JsonMove(diff, OperationType.ADD, tokens, tokens))
+
+        # Pending group, emit
+        if group is not None:
+            yield group
+
+    def _get_non_existing_keys_tokens(self, config1, config2, reverse):
+        for table in self.path_addressing.configdb_sorted_keys_by_backlinks("/", config1, reverse=reverse):
+            for key in self.path_addressing.configdb_sorted_keys_by_backlinks("/" + table, config1, reverse=reverse):
+                if not(table in config2) or not (key in config2[table]):
+                    yield [table, key]
+
+
+class BulkKeyGroupLowLevelMoveGenerator:
+    """
+    This is a Wrapper around BulkLowLevelMoveGenerator that groups the leaf
+    operations together spanning multiple table keys.  For example if someone
+    wants to update PORT/Ethernet0/description and PORT/Ethernet1/description
+    at the same time, it is safe to do so in the same patch group. This grouping
+    exists in order to attempt to optimize the fast path when there are a lot
+    of changes to the same table and there are often very few
+    cross-dependencies.  This will bring down the patch set count considerably
+    for a lot of change operations.  We do still fall back to other more
+    primitive generators if the validators fail so this is an optimization that
+    otherwise doesn't have any impact on the overall outcome, only performance.
+
+    As a secondary optimization, restricted keys (primarily PORT/*/admin_status)
+    operations are grouped together as typically it is ok for all restricted keys
+    to change at the same time for the same table.  If its not, the validator
+    will simply fail it and the generator will move on and "try" something else.
+    """
+    def __init__(self, path_addressing):
+        self.generator = BulkLowLevelMoveGenerator(path_addressing)
+
+    def generate(self, diff):
+        # Handle removals first
+        for move in self.generate_groups(diff, self.generator.generate_remove):
+            yield move
+
+        # Handle removals for restricted keys in bulk independently
+        for move in self.generate_groups(diff, self.generator.generate_remove, restricted_only=True):
+            yield move
+
+        # Handle replacements next
+        for move in self.generate_groups(diff, self.generator.generate_replace):
+            yield move
+
+        # Handle replacements for restricted keys in bulk independently
+        for move in self.generate_groups(diff, self.generator.generate_replace, restricted_only=True):
+            yield move
+
+        # Handle additions last
+        for move in self.generate_groups(diff, self.generator.generate_add):
+            yield move
+
+        # Handle additions for restricted keys in bulk independently
+        for move in self.generate_groups(diff, self.generator.generate_add, restricted_only=True):
+            yield move
+
+    def generate_groups(self, diff, cb, restricted_only: bool = False):
+        group = None
+        for move in cb(diff, min_moves=1, restricted_only=restricted_only):
+            if group is None:
+                group = move
+                continue
+
+            if move.parentTableName() != group.parentTableName():
+                # Don't yield if one entry, we will let the extendable move generator
+                # generate it.
+                if len(group) > 1:
+                    yield group
+                group = move
+                continue
+
+            # group matches move, merge them.
+            group.merge(move)
+
+        # Don't yield if one entry, we will let the extendable move generator
+        # generate it.
+        if group is not None and len(group) > 1:
+            yield group
+
+
+class BulkLowLevelMoveGenerator:
+    """
+    A class that generates low level moves that can be grouped together as a single patch
+    that operate on at most one key at a time. These are moves where the path of the move
+    has no children, these are the end leafs. We are going to use this as a non-extendable
+    generator as the normal LowLevelMoveGenerator will generate the extendable moves.
+    """
+    def __init__(self, path_addressing):
+        self.diff = None
+        self.path_addressing = path_addressing
+        self.requiredval = RequiredValueIdentifier(path_addressing)
+
+    def generate(self, diff):
+        # Handle removals first
+        for move in self.generate_remove(diff):
+            yield move
+
+        # Handle replacements next
+        for move in self.generate_replace(diff):
+            yield move
+
+        # Finally handle additions
+        for move in self.generate_add(diff):
+            yield move
+
+    def generate_remove(self, diff, min_moves: int = 2, restricted_only: bool = False):
+        self.diff = diff
+        tokens = []
+
+        for move in self.__traverse(OperationType.REMOVE, self.diff.current_config, self.diff.target_config, tokens,
+                                    min_moves, restricted_only):
+            yield move
+
+    def generate_replace(self, diff, min_moves: int = 2, restricted_only: bool = False):
+        self.diff = diff
+        tokens = []
+
+        for move in self.__traverse(OperationType.REPLACE, self.diff.current_config, self.diff.target_config, tokens,
+                                    min_moves, restricted_only):
+            yield move
+
+    def generate_add(self, diff, min_moves: int = 2, restricted_only: bool = False):
+        self.diff = diff
+        tokens = []
+
+        for move in self.__traverse(OperationType.ADD, self.diff.current_config, self.diff.target_config, tokens,
+                                    min_moves, restricted_only):
+            yield move
+
+    def __restricted_key(self, tokens, key, invert: bool = False):
+        tokens.append(key)
+        rv = self.requiredval.target_in_required_pattern(tokens)
+        tokens.pop()
+        if invert:
+            if rv:
+                return False
+            return True
+        return rv
+
+    def __traverse(self, op, current_ptr, target_ptr, tokens, min_moves, restricted_only: bool = False):
+        if isinstance(current_ptr, dict):
+            if self.__children_are_leafs(current_ptr) and self.__children_are_leafs(target_ptr):
+                for move in self.__output_bulk_move(op, current_ptr, target_ptr, tokens, min_moves, restricted_only):
+                    yield move
+                return
+
+            # If current and target are different types, skip
+            if not isinstance(target_ptr, dict):
+                return
+
+            # Recurse across children, sorted by backlinks
+            reverse = True
+            if op == OperationType.REMOVE:
+                reverse = False
+
+            for key in self.path_addressing.configdb_sorted_keys_by_backlinks(
+                    self.path_addressing.create_path(tokens), current_ptr, reverse=reverse, configdb_relative=True):
+
+                # Does not exist in target, skip
+                if target_ptr.get(key) is None:
+                    continue
+
+                tokens.append(key)
+                for move in self.__traverse(op, current_ptr[key], target_ptr[key], tokens, min_moves, restricted_only):
+                    yield move
+                tokens.pop()
+            return
+
+        # TODO: implement list support
+        return
+
+    def __children_are_leafs(self, config_ptr):
+        for key in config_ptr:
+            if isinstance(config_ptr[key], dict) or isinstance(config_ptr[key], list):
+                return False
+        return True
+
+    def __output_bulk_move(self, op, current_ptr, target_ptr, tokens, min_moves, restricted_only):
+        match op:
+            case OperationType.REMOVE:
+                for move in self.__output_bulk_remove(current_ptr, target_ptr, tokens, min_moves, restricted_only):
+                    yield move
+            case OperationType.REPLACE:
+                for move in self.__output_bulk_replace(current_ptr, target_ptr, tokens, min_moves, restricted_only):
+                    yield move
+            case OperationType.ADD:
+                for move in self.__output_bulk_add(current_ptr, target_ptr, tokens, min_moves, restricted_only):
+                    yield move
+
+    def __output_bulk_add(self, current_ptr, target_ptr, tokens, min_moves, restricted_only):
+        group = JsonMoveGroup()
+        for key in target_ptr:
+            if current_ptr.get(key) is None and not self.__restricted_key(tokens, key, invert=restricted_only):
+                tokens.append(key)
+                group.append(JsonMove(self.diff, OperationType.ADD, tokens, tokens))
+                tokens.pop()
+
+        # Not a bulk move if there's not more than one action to take
+        if len(group) >= min_moves:
+            yield group
+
+    def __output_bulk_remove(self, current_ptr, target_ptr, tokens, min_moves, restricted_only):
+        group = JsonMoveGroup()
+        for key in current_ptr:
+            if target_ptr.get(key) is None and not self.__restricted_key(tokens, key, invert=restricted_only):
+                tokens.append(key)
+                group.append(JsonMove(self.diff, OperationType.REMOVE, tokens))
+                tokens.pop()
+
+        # Not a bulk move if there's not more than one action to take
+        if len(group) >= min_moves:
+            yield group
+
+    def __output_bulk_replace(self, current_ptr, target_ptr, tokens, min_moves, restricted_only):
+        group = JsonMoveGroup()
+        for key in current_ptr:
+            target_val = target_ptr.get(key)
+            if (target_val is not None and target_val != current_ptr.get(key) and
+                    not self.__restricted_key(tokens, key, invert=restricted_only)):
+                tokens.append(key)
+                group.append(JsonMove(self.diff, OperationType.REPLACE, tokens, tokens))
+                tokens.pop()
+
+        # Not a bulk move if there's not more than one action to take
+        if len(group) >= min_moves:
+            yield group
+
 
 class RemoveCreateOnlyDependencyMoveGenerator:
     """
@@ -1148,6 +1627,7 @@ class RemoveCreateOnlyDependencyMoveGenerator:
     def generate(self, diff):
         current_config = diff.current_config
         target_config = diff.target_config # Final config after applying whole patch
+        reload_config = True
 
         processed_tables = set()
         for path in self.create_only_filter.get_paths(current_config):
@@ -1187,24 +1667,30 @@ class RemoveCreateOnlyDependencyMoveGenerator:
 
                 member_path = f"/{table_to_check}/{member_name}"
 
-                for ref_path in self.path_addressing.find_ref_paths(member_path, current_config):
-                    yield JsonMove(diff, OperationType.REMOVE,
-                                   self.path_addressing.get_path_tokens(ref_path))
+                for ref_path in self.path_addressing.find_ref_paths(member_path, current_config,
+                                                                    reload_config=reload_config):
+                    yield JsonMoveGroup(JsonMove(diff, OperationType.REMOVE,
+                                        self.path_addressing.get_path_tokens(ref_path)))
+
+                # No need to reload config after first call
+                reload_config = False
 
     def _get_create_only_field(self, config, table_to_check,
                                member_name, create_only_field):
         return config[table_to_check][member_name].get(create_only_field, None)
 
 
-class SingleRunLowLevelMoveGenerator:
+class LowLevelMoveGenerator:
     """
-    A class that can only run once to assist LowLevelMoveGenerator with generating the moves.
+    A class to generate the low level moves i.e. moves corresponding to differences between current/target config
+    where the path of the move does not have children.
     """
-    def __init__(self, diff, path_addressing):
-        self.diff = diff
+    def __init__(self, path_addressing):
+        self.diff = None
         self.path_addressing = path_addressing
 
-    def generate(self):
+    def generate(self, diff):
+        self.diff = diff
         current_ptr = self.diff.current_config
         target_ptr = self.diff.target_config
         current_tokens = []
@@ -1311,7 +1797,7 @@ class SingleRunLowLevelMoveGenerator:
         if current_value == target_value:
             return
 
-        yield JsonMove(self.diff, OperationType.REPLACE, current_tokens, target_tokens)
+        yield JsonMoveGroup(JsonMove(self.diff, OperationType.REPLACE, current_tokens, target_tokens))
 
     def _traverse_current(self, ptr, current_tokens):
         if isinstance(ptr, list):
@@ -1321,7 +1807,7 @@ class SingleRunLowLevelMoveGenerator:
 
         if isinstance(ptr, dict):
             if len(ptr) == 0:
-                yield JsonMove(self.diff, OperationType.REMOVE, current_tokens)
+                yield JsonMoveGroup(JsonMove(self.diff, OperationType.REMOVE, current_tokens))
                 return
 
             for key in ptr:
@@ -1338,7 +1824,7 @@ class SingleRunLowLevelMoveGenerator:
 
     def _traverse_current_list(self, ptr, current_tokens):
         if len(ptr) == 0:
-            yield JsonMove(self.diff, OperationType.REMOVE, current_tokens)
+            yield JsonMoveGroup(JsonMove(self.diff, OperationType.REMOVE, current_tokens))
             return
 
         for index, val in enumerate(ptr):
@@ -1348,7 +1834,7 @@ class SingleRunLowLevelMoveGenerator:
             current_tokens.pop()
 
     def _traverse_current_value(self, val, current_tokens):
-        yield JsonMove(self.diff, OperationType.REMOVE, current_tokens)
+        yield JsonMoveGroup(JsonMove(self.diff, OperationType.REMOVE, current_tokens))
 
     def _traverse_target(self, ptr, current_tokens, target_tokens):
         if isinstance(ptr, list):
@@ -1358,7 +1844,7 @@ class SingleRunLowLevelMoveGenerator:
 
         if isinstance(ptr, dict):
             if len(ptr) == 0:
-                yield JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens)
+                yield JsonMoveGroup(JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens))
                 return
 
             for key in ptr:
@@ -1377,7 +1863,7 @@ class SingleRunLowLevelMoveGenerator:
 
     def _traverse_target_list(self, ptr, current_tokens, target_tokens):
         if len(ptr) == 0:
-            yield JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens)
+            yield JsonMoveGroup(JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens))
             return
 
         for index, val in enumerate(ptr):
@@ -1391,7 +1877,7 @@ class SingleRunLowLevelMoveGenerator:
             current_tokens.pop()
 
     def _traverse_target_value(self, val, current_tokens, target_tokens):
-        yield JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens)
+        yield JsonMoveGroup(JsonMove(self.diff, OperationType.ADD, current_tokens, target_tokens))
 
     def _list_to_dict_with_count(self, items):
         counts = dict()
@@ -1403,6 +1889,7 @@ class SingleRunLowLevelMoveGenerator:
             counts[item] = counts.get(item, 0) + 1
 
         return counts
+
 
 class RequiredValueMoveExtender:
     """
@@ -1423,7 +1910,7 @@ class RequiredValueMoveExtender:
         self.identifier = RequiredValueIdentifier(path_addressing)
         self.operation_wrapper = operation_wrapper
 
-    def extend(self, move, diff):
+    def extend(self, move: JsonMove, diff):
         # ignore full config removal because it is not possible by JsonPatch lib
         if move.op_type == OperationType.REMOVE and move.path == "":
             return
@@ -1476,7 +1963,7 @@ class RequiredValueMoveExtender:
             extended_move = self._flip(move, flip_path_value_tuples)
             yield extended_move
 
-    def _flip(self, move, flip_path_value_tuples):
+    def _flip(self, move: JsonMove, flip_path_value_tuples):
         new_value = copy.deepcopy(move.value)
         move_tokens = self.path_addressing.get_path_tokens(move.path)
         for field_path, field_value in flip_path_value_tuples:
@@ -1506,24 +1993,12 @@ class UpperLevelMoveExtender:
       2) If parent was in current but not target, then delete the parent
       3) If parent was in target but not current, then add the parent
     """
-    def extend(self, move, diff):
+    def extend(self, move: JsonMove, diff):
         # if no tokens i.e. whole config
         if not move.current_config_tokens:
             return
 
         upper_current_tokens = move.current_config_tokens[:-1]
-
-        # Don't extend key-level ADD/REPLACE operations to table-level when just adding/modifying keys within an existing table
-        # This prevents incorrectly replacing/removing entire tables when only adding/updating individual keys
-        # We still allow REMOVE operations to be extended to handle dependency cleanup properly
-        if len(upper_current_tokens) == 1:  # This would be a table-level operation
-            table = upper_current_tokens[0]
-            # If table exists in both current and target, don't extend ADD/REPLACE to table level
-            # The key-level operation is sufficient for additions/modifications
-            if table in diff.current_config and table in diff.target_config:
-                if move.op_type in [OperationType.ADD, OperationType.REPLACE]:
-                    return
-
         operation_type = self._get_upper_operation(upper_current_tokens, diff)
 
         upper_target_tokens = None
@@ -1551,7 +2026,7 @@ class DeleteInsteadOfReplaceMoveExtender:
     """
     A class to extend the given REPLACE move by adding a REMOVE move.
     """
-    def extend(self, move, diff):
+    def extend(self, move: JsonMove, diff):
         operation_type = move.op_type
 
         if operation_type != OperationType.REPLACE:
@@ -1565,6 +2040,7 @@ class DeleteInsteadOfReplaceMoveExtender:
 
         yield new_move
 
+
 class DeleteRefsMoveExtender:
     """
     A class to extend the given DELETE move by adding DELETE moves to configs referring to the path in the move.
@@ -1572,14 +2048,15 @@ class DeleteRefsMoveExtender:
     def __init__(self, path_addressing):
         self.path_addressing = path_addressing
 
-    def extend(self, move, diff):
+    def extend(self, move: JsonMove, diff):
         operation_type = move.op_type
 
         if operation_type != OperationType.REMOVE:
             return
 
-        for ref_path in self.path_addressing.find_ref_paths(move.path, diff.current_config):
+        for ref_path in self.path_addressing.find_ref_paths(move.path, diff.current_config, reload_config=True):
             yield JsonMove(diff, OperationType.REMOVE, self.path_addressing.get_path_tokens(ref_path))
+
 
 class DfsSorter:
     def __init__(self, move_wrapper):
@@ -1599,12 +2076,15 @@ class DfsSorter:
 
         for move in moves:
             if self.move_wrapper.validate(move, diff):
-                new_diff = self.move_wrapper.simulate(move, diff)
+                # NOTE: due to the recursive nature, we can't modify in-place as on error we will
+                #       receive "RuntimeError: dictionary changed size during iteration"
+                new_diff = self.move_wrapper.simulate(move, diff, in_place=False)
                 new_moves = self.sort(new_diff)
                 if new_moves is not None:
                     return [move] + new_moves
 
         return None
+
 
 class BfsSorter:
     def __init__(self, move_wrapper):
@@ -1641,6 +2121,7 @@ class BfsSorter:
 
         return None
 
+
 class MemoizationSorter:
     def __init__(self, move_wrapper):
         self.visited = {}
@@ -1671,10 +2152,12 @@ class MemoizationSorter:
         self.mem[diff_hash] = bst_moves
         return bst_moves
 
+
 class Algorithm(Enum):
     DFS = 1
     BFS = 2
     MEMOIZATION = 3
+
 
 class SortAlgorithmFactory:
     def __init__(self, operation_wrapper, config_wrapper, path_addressing):
@@ -1686,8 +2169,12 @@ class SortAlgorithmFactory:
         move_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
                            LowLevelMoveGenerator(self.path_addressing)]
         # TODO: Enable TableLevelMoveGenerator once it is confirmed whole table can be updated at the same time
-        move_non_extendable_generators = [BulkLeafListMoveGenerator(),
-                                          KeyLevelMoveGenerator()]
+        move_non_extendable_generators = [RemoveCreateOnlyDependencyMoveGenerator(self.path_addressing),
+                                          BulkLeafListMoveGenerator(self.path_addressing),
+                                          BulkKeyLevelMoveGenerator(self.path_addressing),
+                                          KeyLevelMoveGenerator(self.path_addressing),
+                                          BulkKeyGroupLowLevelMoveGenerator(self.path_addressing),
+                                          BulkLowLevelMoveGenerator(self.path_addressing)]
         move_extenders = [RequiredValueMoveExtender(self.path_addressing, self.operation_wrapper),
                           UpperLevelMoveExtender(),
                           DeleteInsteadOfReplaceMoveExtender(),
@@ -1712,6 +2199,7 @@ class SortAlgorithmFactory:
             raise ValueError(f"Algorithm {algorithm} is not supported")
 
         return sorter
+
 
 class StrictPatchSorter:
     def __init__(self, config_wrapper, patch_wrapper, inner_patch_sorter=None):
@@ -1775,11 +2263,12 @@ class IgnorePathsFromYangConfigSplitter:
 
             # Add to config_without_yang from config_with_yang
             tokens = self.path_addressing.get_path_tokens(path)
-            add_move = JsonMove(Diff(config_without_yang, config_with_yang), OperationType.ADD, tokens, tokens)
+            add_move = JsonMoveGroup(JsonMove(Diff(config_without_yang, config_with_yang), OperationType.ADD, tokens,
+                                              tokens))
             config_without_yang = add_move.apply(config_without_yang)
 
             # Remove from config_with_yang
-            remove_move = JsonMove(Diff(config_with_yang, {}), OperationType.REMOVE, tokens)
+            remove_move = JsonMoveGroup(JsonMove(Diff(config_with_yang, {}), OperationType.REMOVE, tokens))
             config_with_yang = remove_move.apply(config_with_yang)
 
         # Splitting the config based on 'ignore_paths_from_yang_list' can result in empty tables.
@@ -1975,7 +2464,7 @@ class PatchSorter:
         current_config = preloaded_current_config if preloaded_current_config else self.config_wrapper.get_config_db_as_json()
         target_config = self.patch_wrapper.simulate_patch(patch, current_config)
 
-        diff = Diff(current_config, target_config)
+        diff = Diff(copy.deepcopy(current_config), target_config)
 
         sort_algorithm = self.sort_algorithm_factory.create(algorithm)
         moves = sort_algorithm.sort(diff)
@@ -1983,6 +2472,6 @@ class PatchSorter:
         if moves is None:
             raise GenericConfigUpdaterError("There is no possible sorting")
 
-        changes = [JsonChange(move.patch) for move in moves]
+        changes = [JsonChange(move.get_jsonpatch()) for move in moves]
 
         return changes

--- a/generic_config_updater/patch_sorter.py
+++ b/generic_config_updater/patch_sorter.py
@@ -2252,7 +2252,8 @@ class SortAlgorithmFactory:
                                           BulkKeyLevelMoveGenerator(self.path_addressing),
                                           KeyLevelMoveGenerator(self.path_addressing),
                                           BulkKeyGroupLowLevelMoveGenerator(self.path_addressing),
-                                          BulkLowLevelMoveGenerator(self.path_addressing)]
+                                          BulkLowLevelMoveGenerator(self.path_addressing),
+                                          BulkLeafListMoveGenerator(self.path_addressing)]
         move_extenders = [RequiredValueMoveExtender(self.path_addressing, self.operation_wrapper),
                           UpperLevelMoveExtender(),
                           DeleteInsteadOfReplaceMoveExtender(),

--- a/sonic_package_manager/manager.py
+++ b/sonic_package_manager/manager.py
@@ -5,7 +5,6 @@ import functools
 import os
 import pkgutil
 import tempfile
-import yang as ly
 from inspect import signature
 from typing import Any, Iterable, List, Callable, Dict, Optional
 
@@ -1299,7 +1298,7 @@ class PackageManager:
         docker_api = DockerApi(docker.from_env(), ProgressManager())
         registry_resolver = RegistryResolver()
         metadata_resolver = MetadataResolver(docker_api, registry_resolver)
-        cfg_mgmt = config_mgmt.ConfigMgmt(source=INIT_CFG_JSON, sonicYangOptions=ly.LY_CTX_DISABLE_SEARCHDIR_CWD)
+        cfg_mgmt = config_mgmt.ConfigMgmt(source=INIT_CFG_JSON)
         cli_generator = CliGenerator(log)
         feature_registry = FeatureRegistry(SonicDB)
         service_creator = ServiceCreator(feature_registry,

--- a/tests/generic_config_updater/change_applier_test.py
+++ b/tests/generic_config_updater/change_applier_test.py
@@ -290,7 +290,6 @@ class TestDryRunChangeApplier(unittest.TestCase):
         change = Mock()
         config_wrapper = Mock()
         applier = generic_config_updater.change_applier.DryRunChangeApplier(config_wrapper)
-        running_config = {}
 
         # Act
         current_config = copy.deepcopy(running_config)

--- a/tests/generic_config_updater/change_applier_test.py
+++ b/tests/generic_config_updater/change_applier_test.py
@@ -128,7 +128,8 @@ def set_entry(config_db, tbl, key, data):
 # mimics JsonChange.apply
 #
 class mock_obj:
-    def apply(self, config):
+    def apply(self, config, in_place):
+        config = copy.deepcopy(config)
         json_change = json_changes[json_change_index]
 
         update = copy.deepcopy(json_change["update"])
@@ -255,7 +256,8 @@ class TestChangeApplier(unittest.TestCase):
 
             debug_print("main: json_change_index={}".format(json_change_index))
 
-            applier.apply(mock_obj())
+            current_config = copy.deepcopy(start_running_config)
+            current_config = applier.apply(current_config, mock_obj())
 
             debug_print(f"Testing json_change {json_change_index}")
 
@@ -288,10 +290,12 @@ class TestDryRunChangeApplier(unittest.TestCase):
         change = Mock()
         config_wrapper = Mock()
         applier = generic_config_updater.change_applier.DryRunChangeApplier(config_wrapper)
+        running_config = {}
 
         # Act
-        applier.apply(change)
-        applier.remove_backend_tables_from_config(change)
+        current_config = copy.deepcopy(running_config)
+        current_config = applier.apply(current_config, change)
+        current_config = applier.remove_backend_tables_from_config(current_config)
 
         # Assert
-        applier.config_wrapper.apply_change_to_config_db.assert_has_calls([call(change)])
+        applier.config_wrapper.apply_change_to_config_db.assert_called()

--- a/tests/generic_config_updater/field_operation_validator_test.py
+++ b/tests/generic_config_updater/field_operation_validator_test.py
@@ -229,6 +229,44 @@ class TestValidateFieldOperation(unittest.TestCase):
         config_wrapper = gu_common.ConfigWrapper()
         self.assertRaises(gu_common.IllegalPatchOperationError, config_wrapper.validate_field_operation, old_config, target_config)
 
+    @patch("sonic_py_common.device_info.get_sonic_version_info",
+           mock.Mock(return_value={"build_version": "20241211.49"}))
+    @patch("generic_config_updater.field_operation_validators.get_asic_name",
+           mock.Mock(return_value="spc1"))
+    @patch("os.path.exists", mock.Mock(return_value=True))
+    @patch(
+        "builtins.open",
+        mock_open(
+            read_data=(
+                '{"tables": {"BUFFER_POOL": {'
+                '"field_operation_validators": ['
+                '"generic_config_updater.field_operation_validators.rdma_config_update_validator"'
+                '], "validator_data": {"rdma_config_update_validator": {"Blocked ops": '
+                '{"fields": ["ingress_lossless_pool/xoff", '
+                '"ingress_lossless_pool/size", "egress_lossy_pool/size"], '
+                '"operations": [], "platforms": {"spc1": "20181100"}}}}}}}'
+            )
+        )
+    )
+    def test_validate_field_operation_illegal__buffer_pool(self):
+        old_config = {
+            "BUFFER_POOL": {
+                "ingress_lossless_pool": {"xoff": "1000"}
+            }
+        }
+        target_config = {
+            "BUFFER_POOL": {
+                "ingress_lossless_pool": {"xoff": "2000"}
+            }
+        }
+        config_wrapper = gu_common.ConfigWrapper()
+        self.assertRaises(
+            gu_common.IllegalPatchOperationError,
+            config_wrapper.validate_field_operation,
+            old_config,
+            target_config
+        )
+
     def test_validate_field_operation_legal__rm_loopback1(self):
         old_config = {
             "LOOPBACK_INTERFACE": {

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -410,9 +410,7 @@
                         "stage": "ingress",
                         "type": "L3"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/ACL_TABLE/EVERFLOW",
@@ -424,9 +422,7 @@
                         "stage": "ingress",
                         "type": "MIRROR"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/ACL_TABLE/EVERFLOWV6",
@@ -541,9 +537,13 @@
         "expected_changes": [
             [
                 {
-                    "op": "add",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
-                    "value": "Ethernet0"
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet0",
+                        "Ethernet4",
+                        "Ethernet8"
+                    ]
                 }
             ]
         ]
@@ -606,9 +606,7 @@
                     "op": "add",
                     "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
                     "value": {}
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128",
@@ -806,9 +804,7 @@
                         "description": "",
                         "speed": "10000"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/PORT/Ethernet2",
@@ -818,9 +814,7 @@
                         "description": "",
                         "speed": "10000"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/PORT/Ethernet1",
@@ -850,18 +844,14 @@
                     "value": {
                         "tagging_mode": "untagged"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/VLAN_MEMBER/Vlan100|Ethernet3",
                     "value": {
                         "tagging_mode": "untagged"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/VLAN_MEMBER/Vlan100|Ethernet2",
@@ -881,23 +871,14 @@
             ],
             [
                 {
-                    "op": "add",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1",
-                    "value": "Ethernet1"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/2",
-                    "value": "Ethernet2"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/3",
-                    "value": "Ethernet3"
+                    "op": "replace",
+                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports",
+                    "value": [
+                        "Ethernet0",
+                        "Ethernet1",
+                        "Ethernet2",
+                        "Ethernet3"
+                    ]
                 }
             ]
         ]
@@ -1032,15 +1013,11 @@
                 {
                     "op": "remove",
                     "path": "/VLAN_MEMBER/Vlan100|Ethernet1"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/VLAN_MEMBER/Vlan100|Ethernet2"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/VLAN_MEMBER/Vlan100|Ethernet3"
@@ -1411,9 +1388,7 @@
                     "op": "add",
                     "path": "/VLAN_INTERFACE/Vlan1000|fc02:1000::1~164",
                     "value": {}
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/VLAN_INTERFACE/Vlan1000|192.168.0.1~121",
@@ -1451,9 +1426,7 @@
                     "op": "replace",
                     "path": "/CRM/Config/acl_counter_high_threshold",
                     "value": "80"
-                }
-            ],
-            [
+                },
                 {
                     "op": "replace",
                     "path": "/CRM/Config/acl_counter_low_threshold",
@@ -1560,15 +1533,12 @@
         "expected_changes": [
             [
                 {
-                    "op": "remove",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0"
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
-                    "value": "Ethernet0"
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet0",
+                        "Ethernet8"
+                    ]
                 }
             ]
         ]
@@ -1775,8 +1745,13 @@
         "expected_changes": [
             [
                 {
-                    "op": "remove",
-                    "path": "/VLAN/Vlan1000/dhcp_servers/0"
+                    "op": "replace",
+                    "path": "/VLAN/Vlan1000/dhcp_servers",
+                    "value": [
+                        "192.0.0.2",
+                        "192.0.0.3",
+                        "192.0.0.4"
+                    ]
                 }
             ]
         ]
@@ -2146,21 +2121,19 @@
                 {
                     "op": "remove",
                     "path": "/ACL_TABLE/NO-NSW-PACL-V4"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/ACL_TABLE/DATAACL"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/ACL_TABLE/EVERFLOW"
-                }
-            ],
-            [
+                },
+                {
+                    "op": "remove",
+                    "path": "/ACL_TABLE/EVERFLOWV6"
+                },
                 {
                     "op": "remove",
                     "path": "/ACL_TABLE"
@@ -2223,9 +2196,7 @@
                     "op": "add",
                     "path": "/LOOPBACK_INTERFACE/Loopback1|20.2.0.32~132",
                     "value": {}
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/LOOPBACK_INTERFACE/Loopback1|2200:2::32~1128",
@@ -2409,8 +2380,8 @@
                     "value": {
                         "Ethernet0": {
                             "alias": "Eth1",
-                            "description": "Ethernet0 100G link",
                             "lanes": "67",
+                            "description": "Ethernet0 100G link",
                             "speed": "100000"
                         }
                     }
@@ -2512,9 +2483,7 @@
                     "op": "add",
                     "path": "/LOOPBACK_INTERFACE/Loopback0|10.1.0.32~132",
                     "value": {}
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/LOOPBACK_INTERFACE/Loopback0|1100:1::32~1128",
@@ -2583,9 +2552,7 @@
                         "nhopself": "0",
                         "rrclient": "0"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.61",
@@ -3911,6 +3878,28 @@
         "expected_changes": [
             [
                 {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOW/ports",
+                    "value": [
+                        "Ethernet64",
+                        "Ethernet68",
+                        "Ethernet72"
+                    ]
+                }
+            ],
+            [
+                {
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet64",
+                        "Ethernet68",
+                        "Ethernet72"
+                    ]
+                }
+            ],
+            [
+                {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.33",
                     "value": {
@@ -3923,9 +3912,7 @@
                         "nhopself": "0",
                         "rrclient": "0"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::42",
@@ -3948,9 +3935,7 @@
                     "value": {
                         "profile": "pg_lossless_40000_40m_profile"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BUFFER_PG/Ethernet64|0",
@@ -3966,18 +3951,14 @@
                     "value": {
                         "profile": "egress_lossy_profile"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BUFFER_QUEUE/Ethernet64|3-4",
                     "value": {
                         "profile": "egress_lossless_profile"
                     }
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BUFFER_QUEUE/Ethernet64|5-6",
@@ -3999,27 +3980,6 @@
             [
                 {
                     "op": "add",
-                    "path": "/INTERFACE/Ethernet64",
-                    "value": {}
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/INTERFACE/Ethernet64|10.0.0.32~131",
-                    "value": {}
-                }
-            ],
-            [
-                {
-                    "op": "add",
-                    "path": "/INTERFACE/Ethernet64|FC00::41~1126",
-                    "value": {}
-                }
-            ],
-            [
-                {
-                    "op": "add",
                     "path": "/PORT_QOS_MAP/Ethernet64",
                     "value": {
                         "dscp_to_tc_map": "AZURE",
@@ -4033,15 +3993,20 @@
             [
                 {
                     "op": "add",
-                    "path": "/ACL_TABLE/EVERFLOW/ports/0",
-                    "value": "Ethernet64"
+                    "path": "/INTERFACE/Ethernet64",
+                    "value": {}
                 }
             ],
             [
                 {
                     "op": "add",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0",
-                    "value": "Ethernet64"
+                    "path": "/INTERFACE/Ethernet64|10.0.0.32~131",
+                    "value": {}
+                },
+                {
+                    "op": "add",
+                    "path": "/INTERFACE/Ethernet64|FC00::41~1126",
+                    "value": {}
                 }
             ],
             [
@@ -4049,317 +4014,227 @@
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.1/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.5/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.9/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.13/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.17/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.21/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.25/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.29/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.35/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.37/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.39/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.41/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.43/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.45/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.47/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.49/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.51/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.53/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.55/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.57/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.59/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.61/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/10.0.0.63/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::1a/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::2/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::2a/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::3a/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::4a/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::4e/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::5a/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::5e/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::6a/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::6e/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::7a/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::7e/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::12/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::22/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::32/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::46/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::52/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::56/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::62/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::66/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::72/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::76/admin_status",
                     "value": "up"
-                }
-            ],
-            [
+                },
                 {
                     "op": "add",
                     "path": "/BGP_NEIGHBOR/fc00::a/admin_status",
@@ -5544,29 +5419,29 @@
         "expected_changes": [
             [
                 {
-                    "op": "remove",
-                    "path": "/BGP_NEIGHBOR/10.0.0.33"
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOW/ports",
+                    "value": [
+                        "Ethernet68",
+                        "Ethernet72"
+                    ]
                 }
             ],
             [
                 {
-                    "op": "remove",
-                    "path": "/BGP_NEIGHBOR/fc00::42"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/DEVICE_NEIGHBOR/Ethernet64"
+                    "op": "replace",
+                    "path": "/ACL_TABLE/EVERFLOWV6/ports",
+                    "value": [
+                        "Ethernet68",
+                        "Ethernet72"
+                    ]
                 }
             ],
             [
                 {
                     "op": "remove",
                     "path": "/INTERFACE/Ethernet64|10.0.0.32~131"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/INTERFACE/Ethernet64|FC00::41~1126"
@@ -5581,286 +5456,200 @@
             [
                 {
                     "op": "remove",
-                    "path": "/ACL_TABLE/EVERFLOW/ports/0"
+                    "path": "/DEVICE_NEIGHBOR/Ethernet64"
                 }
             ],
             [
                 {
                     "op": "remove",
-                    "path": "/ACL_TABLE/EVERFLOWV6/ports/0"
+                    "path": "/BGP_NEIGHBOR/10.0.0.33"
+                },
+                {
+                    "op": "remove",
+                    "path": "/BGP_NEIGHBOR/fc00::42"
                 }
             ],
             [
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.1/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.5/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.9/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.13/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.17/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.21/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.25/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.29/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.35/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.37/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.39/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.41/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.43/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.45/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.47/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.49/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.51/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.53/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.55/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.57/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.59/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.61/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/10.0.0.63/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::1a/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::2/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::2a/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::3a/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::4a/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::4e/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::5a/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::5e/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::6a/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::6e/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::7a/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::7e/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::12/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::22/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::32/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::46/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::52/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::56/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::62/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::66/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::72/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::76/admin_status"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BGP_NEIGHBOR/fc00::a/admin_status"
@@ -5889,9 +5678,7 @@
                 {
                     "op": "remove",
                     "path": "/BUFFER_PG/Ethernet64|3-4"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BUFFER_PG/Ethernet64|0"
@@ -5901,15 +5688,11 @@
                 {
                     "op": "remove",
                     "path": "/BUFFER_QUEUE/Ethernet64|0-2"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BUFFER_QUEUE/Ethernet64|3-4"
-                }
-            ],
-            [
+                },
                 {
                     "op": "remove",
                     "path": "/BUFFER_QUEUE/Ethernet64|5-6"

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -743,27 +743,6 @@
         "expected_changes": [
             [
                 {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/alias",
-                    "value": "Eth1/1"
-                }
-            ],
-            [
-                {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/description",
-                    "value": ""
-                }
-            ],
-            [
-                {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/speed",
-                    "value": "10000"
-                }
-            ],
-            [
-                {
                     "op": "remove",
                     "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports"
                 }
@@ -1012,42 +991,37 @@
             [
                 {
                     "op": "remove",
-                    "path": "/VLAN_MEMBER/Vlan100|Ethernet1"
-                },
-                {
-                    "op": "remove",
-                    "path": "/VLAN_MEMBER/Vlan100|Ethernet2"
-                },
-                {
-                    "op": "remove",
-                    "path": "/VLAN_MEMBER/Vlan100|Ethernet3"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
                     "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/0"
                 }
             ],
             [
                 {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/alias",
-                    "value": "Eth1"
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet0"
                 }
             ],
             [
                 {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/description",
-                    "value": "Ethernet0 100G link"
+                    "op": "remove",
+                    "path": "/PORT/Ethernet0"
                 }
             ],
             [
                 {
-                    "op": "replace",
-                    "path": "/PORT/Ethernet0/speed",
-                    "value": "100000"
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet1"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER/Vlan100|Ethernet2"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/VLAN_MEMBER"
                 }
             ],
             [
@@ -1112,25 +1086,6 @@
             ],
             [
                 {
-                    "op": "add",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/0",
-                    "value": "Ethernet0"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports/1"
-                }
-            ],
-            [
-                {
-                    "op": "remove",
-                    "path": "/PORT/Ethernet3"
-                }
-            ],
-            [
-                {
                     "op": "remove",
                     "path": "/ACL_TABLE/NO-NSW-PACL-V4/ports"
                 }
@@ -1138,10 +1093,8 @@
             [
                 {
                     "op": "remove",
-                    "path": "/VLAN_MEMBER"
-                }
-            ],
-            [
+                    "path": "/PORT/Ethernet3"
+                },
                 {
                     "op": "remove",
                     "path": "/PORT"
@@ -1154,8 +1107,8 @@
                     "value": {
                         "Ethernet0": {
                             "alias": "Eth1",
-                            "description": "Ethernet0 100G link",
                             "lanes": "65, 66, 67, 68",
+                            "description": "Ethernet0 100G link",
                             "speed": "100000"
                         }
                     }
@@ -5702,6 +5655,126 @@
                 {
                     "op": "remove",
                     "path": "/PORT_QOS_MAP/Ethernet64"
+                }
+            ]
+        ]
+    },
+    "CREATE_ONLY_PATH_TEST_MIRROR_SESSION__SUCCESS": {
+        "desc": "Mirror changes should not remove ACL Table.",
+        "current_config": {
+            "MIRROR_SESSION": {
+                "EVERFLOW_TUNNEL": {
+                    "dscp": "8",
+                    "dst_ip": "200.1.1.200",
+                    "src_ip": "100.1.1.1",
+                    "ttl": "255",
+                    "type": "ERSPAN"
+                }
+            },
+            "ACL_TABLE": {
+                "DATAACL": {
+                    "policy_desc": "DATAACL",
+                    "ports": [
+                        "Ethernet4"
+                    ],
+                    "stage": "ingress",
+                    "type": "L3"
+                },
+                "EVERFLOW": {
+                    "policy_desc": "EVERFLOW",
+                    "ports": [
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRROR"
+                },
+                "EVERFLOWV6": {
+                    "policy_desc": "EVERFLOWV6",
+                    "ports": [
+                        "Ethernet4",
+                        "Ethernet8"
+                    ],
+                    "stage": "ingress",
+                    "type": "MIRRORV6"
+                }
+            },
+            "ACL_RULE": {
+                "DATAACL|RULE_1": {
+                    "DST_IP": "192.168.1.1/32",
+                    "IP_TYPE": "IP",
+                    "L4_DST_PORT": "22",
+                    "PACKET_ACTION": "DROP",
+                    "PRIORITY": "10"
+                },
+                "EVERFLOW|RULE_1": {
+                    "PRIORITY": "1000",
+                    "IP_TYPE": "IP",
+                    "MIRROR_INGRESS_ACTION": "EVERFLOW_TUNNEL"
+                }
+            },
+            "PORT": {
+                "Ethernet4": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/4",
+                    "description": "Servers0:eth0",
+                    "index": "1",
+                    "lanes": "29,30,31,32",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                },
+                "Ethernet8": {
+                    "admin_status": "up",
+                    "alias": "fortyGigE0/8",
+                    "description": "Servers1:eth0",
+                    "index": "2",
+                    "lanes": "33,34,35,36",
+                    "mtu": "9100",
+                    "pfc_asym": "off",
+                    "speed": "40000"
+                }
+            }
+        },
+        "patch": [
+            {
+                "op": "replace",
+                "path": "/MIRROR_SESSION/EVERFLOW_TUNNEL/dst_ip",
+                "value": "200.1.1.203"
+            }
+        ],
+        "expected_changes": [
+            [
+                {
+                    "op": "remove",
+                    "path": "/ACL_RULE/EVERFLOW|RULE_1/MIRROR_INGRESS_ACTION"
+                }
+            ],
+            [
+                {
+                    "op": "remove",
+                    "path": "/MIRROR_SESSION"
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/MIRROR_SESSION",
+                    "value": {
+                        "EVERFLOW_TUNNEL": {
+                            "dscp": "8",
+                            "dst_ip": "200.1.1.203",
+                            "src_ip": "100.1.1.1",
+                            "ttl": "255",
+                            "type": "ERSPAN"
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    "op": "add",
+                    "path": "/ACL_RULE/EVERFLOW|RULE_1/MIRROR_INGRESS_ACTION",
+                    "value": "EVERFLOW_TUNNEL"
                 }
             ]
         ]

--- a/tests/generic_config_updater/files/patch_sorter_test_success.json
+++ b/tests/generic_config_updater/files/patch_sorter_test_success.json
@@ -4215,7 +4215,8 @@
                     "value": "up"
                 }
             ]
-        ]
+        ],
+        "skip_exact_change_list_match": true
     },
     "REMOVE_RACK": {
         "desc": "Remove a rack and all its related settings",
@@ -5657,7 +5658,8 @@
                     "path": "/PORT_QOS_MAP/Ethernet64"
                 }
             ]
-        ]
+        ],
+        "skip_exact_change_list_match": true
     },
     "CREATE_ONLY_PATH_TEST_MIRROR_SESSION__SUCCESS": {
         "desc": "Mirror changes should not remove ACL Table.",

--- a/tests/generic_config_updater/gcu_feature_patch_application_test.py
+++ b/tests/generic_config_updater/gcu_feature_patch_application_test.py
@@ -94,10 +94,9 @@ class TestFeaturePatchApplication(unittest.TestCase):
         patch_wrapper = PatchWrapper(config_wrapper)
         return gu.PatchApplier(config_wrapper=config_wrapper, patch_wrapper=patch_wrapper, changeapplier=change_applier)
     
-    @patch('generic_config_updater.change_applier.get_config_db_as_json', side_effect=get_running_config)
     @patch("generic_config_updater.change_applier.get_config_db")
     @patch("generic_config_updater.change_applier.set_config")
-    def run_single_success_case_applier(self, data, mock_set, mock_db, mock_get_config_db_as_json):
+    def run_single_success_case_applier(self, data, mock_set, mock_db):
         current_config = data["current_config"]
         expected_config = data["expected_config"]
         patch = jsonpatch.JsonPatch(data["patch"])
@@ -125,8 +124,7 @@ class TestFeaturePatchApplication(unittest.TestCase):
         self.assertEqual(simulated_config, expected_config)
     
     @patch("generic_config_updater.change_applier.get_config_db")
-    @patch('generic_config_updater.change_applier.get_config_db_as_json', side_effect=get_running_config)
-    def run_single_failure_case_applier(self, data, mock_db, mock_get_config_db_as_json):
+    def run_single_failure_case_applier(self, data, mock_db):
         current_config = data["current_config"]
         patch = jsonpatch.JsonPatch(data["patch"])
         expected_error_substrings = data["expected_error_substrings"]

--- a/tests/generic_config_updater/generic_updater_test.py
+++ b/tests/generic_config_updater/generic_updater_test.py
@@ -41,7 +41,7 @@ class TestPatchApplier(unittest.TestCase):
         patch_applier.patch_wrapper.simulate_patch.assert_has_calls(
             [call(Files.MULTI_OPERATION_CONFIG_DB_PATCH, Files.CONFIG_DB_AS_JSON)])
         patch_applier.patchsorter.sort.assert_has_calls([call(Files.MULTI_OPERATION_CONFIG_DB_PATCH)])
-        patch_applier.changeapplier.apply.assert_has_calls([call(changes[0]), call(changes[1])])
+        patch_applier.changeapplier.apply.assert_called()
         patch_applier.patch_wrapper.verify_same_json.assert_has_calls(
             [call(Files.CONFIG_DB_AFTER_MULTI_PATCH, Files.CONFIG_DB_AFTER_MULTI_PATCH)])
 
@@ -72,7 +72,7 @@ class TestPatchApplier(unittest.TestCase):
             create_side_effect_dict({(str(Files.MULTI_OPERATION_CONFIG_DB_PATCH),): changes})
 
         changeapplier = Mock()
-        changeapplier.apply.side_effect = create_side_effect_dict({(str(changes[0]),): 0, (str(changes[1]),): 0})
+        changeapplier.apply.side_effect = lambda current_config, change: current_config
 
         return gu.PatchApplier(patchsorter, changeapplier, config_wrapper, patch_wrapper)
 

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -56,11 +56,10 @@ class TestDryRunConfigWrapper(unittest.TestCase):
                   ]
 
         expected = imitated_config_db
+        actual = config_wrapper.get_config_db_as_json()
         for change in changes:
             # Act
-            config_wrapper.apply_change_to_config_db(change)
-
-            actual = config_wrapper.get_config_db_as_json()
+            actual = config_wrapper.apply_change_to_config_db(actual, change)
             expected = change.apply(expected)
 
             # Assert

--- a/tests/generic_config_updater/gu_common_test.py
+++ b/tests/generic_config_updater/gu_common_test.py
@@ -221,6 +221,92 @@ class TestConfigWrapper(unittest.TestCase):
         self.assertEqual(expected, actual)
         self.assertIsNotNone(error)
 
+    def test_validate_config_db_config__same_config_called_twice__loadData_called_once(self):
+        """Cache hit: second call with same config must not call loadData again."""
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        mock_sy.loadYangModel = MagicMock()
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        config = {"ACL_TABLE": {}}
+
+        config_wrapper.validate_config_db_config(config)
+        config_wrapper.validate_config_db_config(config)
+
+        # loadData should only be called once — second call hits the result cache
+        mock_sy.loadData.assert_called_once()
+
+    def test_validate_config_db_config__different_configs__loadData_called_each_time(self):
+        """Cache miss: different configs must each call loadData."""
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        config_a = {"ACL_TABLE": {"rule1": {}}}
+        config_b = {"ACL_TABLE": {"rule2": {}}}
+
+        config_wrapper.validate_config_db_config(config_a)
+        config_wrapper.validate_config_db_config(config_b)
+
+        self.assertEqual(2, mock_sy.loadData.call_count)
+
+    def test_find_ref_paths__after_validate_same_config__loadData_skipped(self):
+        """
+        Core optimization: if validate_config_db_config already loaded config into sy,
+        find_ref_paths with the same config must skip loadData entirely.
+        """
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        mock_sy.root = MagicMock()
+        mock_sy.root.find_path = MagicMock(return_value=MagicMock(data=MagicMock(return_value=[])))
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        path_addressing = gu_common.PathAddressing(config_wrapper)
+        config = {"ACL_TABLE": {}}
+
+        # First: validate loads the config into sy and sets _currently_loaded_hash
+        config_wrapper.validate_config_db_config(config)
+        self.assertIsNotNone(config_wrapper._currently_loaded_hash,
+                             "validate_config_db_config should have set _currently_loaded_hash")
+        load_count_after_validate = mock_sy.loadData.call_count
+
+        # Second: find_ref_paths with same config should NOT call loadData again
+        path_addressing.find_ref_paths("/ACL_TABLE", config, reload_config=True)
+        load_count_after_find = mock_sy.loadData.call_count
+
+        self.assertEqual(load_count_after_validate, load_count_after_find,
+                         "find_ref_paths should skip loadData when validate already loaded same config")
+
+    def test_find_ref_paths__after_validate_different_config__loadData_called(self):
+        """
+        Cache miss in find_ref_paths: if validate loaded config_A, calling find_ref_paths
+        with config_B must still call loadData.
+        """
+        config_wrapper = gu_common.ConfigWrapper()
+        mock_sy = MagicMock()
+        mock_sy.loadData = MagicMock()
+        mock_sy.root = MagicMock()
+        mock_sy.root.find_path = MagicMock(return_value=MagicMock(data=MagicMock(return_value=[])))
+        config_wrapper.sonic_yang_with_loaded_models = mock_sy
+
+        path_addressing = gu_common.PathAddressing(config_wrapper)
+        config_a = {"ACL_TABLE": {"rule1": {}}}
+        config_b = {"ACL_TABLE": {"rule2": {}}}
+
+        config_wrapper.validate_config_db_config(config_a)
+        self.assertIsNotNone(config_wrapper._currently_loaded_hash,
+                             "validate_config_db_config should have set _currently_loaded_hash")
+        load_count_after_validate = mock_sy.loadData.call_count
+
+        path_addressing.find_ref_paths("/ACL_TABLE", config_b, reload_config=True)
+        load_count_after_find = mock_sy.loadData.call_count
+
+        self.assertEqual(load_count_after_find, load_count_after_validate + 1,
+                         "find_ref_paths should call loadData exactly once when config differs")
+
     def test_validate_bgp_peer_group__valid_non_intersecting_ip_ranges__returns_true(self):
         # Arrange
         config_wrapper = gu_common.ConfigWrapper()
@@ -450,48 +536,6 @@ class TestConfigWrapper(unittest.TestCase):
         # Assert
         self.assertDictEqual({"any_table": {"key": "value"}}, actual)
 
-    def test_create_sonic_yang_with_loaded_models__creates_new_sonic_yang_every_call(self):
-        # check yang models fields are the same or None, non-yang model fields are different
-        def check(sy1, sy2):
-            # instances are different
-            self.assertNotEqual(sy1, sy2)
-
-            # yang models fields are same or None
-            self.assertTrue(sy1.confDbYangMap is sy2.confDbYangMap)
-            self.assertTrue(sy1.ctx is sy2.ctx)
-            self.assertTrue(sy1.DEBUG is sy2.DEBUG)
-            self.assertTrue(sy1.preProcessedYang is sy2.preProcessedYang)
-            self.assertTrue(sy1.SYSLOG_IDENTIFIER is sy2.SYSLOG_IDENTIFIER)
-            self.assertTrue(sy1.yang_dir is sy2.yang_dir)
-            self.assertTrue(sy1.yangFiles is sy2.yangFiles)
-            self.assertTrue(sy1.yJson is sy2.yJson)
-            self.assertTrue(not(hasattr(sy1, 'module')) or sy1.module is None) # module is unused, might get deleted
-            self.assertTrue(not(hasattr(sy2, 'module')) or sy2.module is None)
-
-            # non yang models fields are different
-            self.assertFalse(sy1.root is sy2.root)
-            self.assertFalse(sy1.jIn is sy2.jIn)
-            self.assertFalse(sy1.tablesWithOutYang is sy2.tablesWithOutYang)
-            self.assertFalse(sy1.xlateJson is sy2.xlateJson)
-            self.assertFalse(sy1.revXlateJson is sy2.revXlateJson)
-
-        config_wrapper = gu_common.ConfigWrapper()
-        self.assertTrue(config_wrapper.sonic_yang_with_loaded_models is None)
-
-        sy1 = config_wrapper.create_sonic_yang_with_loaded_models()
-        sy2 = config_wrapper.create_sonic_yang_with_loaded_models()
-
-        # Simulating loading non-yang model fields
-        sy1.loadData(Files.ANY_CONFIG_DB)
-        sy1.getData()
-
-        # Simulating loading non-yang model fields
-        sy2.loadData(Files.ANY_CONFIG_DB)
-        sy2.getData()
-
-        check(sy1, sy2)
-        check(sy1, config_wrapper.sonic_yang_with_loaded_models)
-        check(sy2, config_wrapper.sonic_yang_with_loaded_models)
 
 class TestPatchWrapper(unittest.TestCase):
     def setUp(self):
@@ -689,7 +733,7 @@ class TestPathAddressing(unittest.TestCase):
             self.assertEqual(expected, actual)
 
         check("", [])
-        check("/", [""])
+        check("/", [])
         check("/token", ["token"])
         check("/more/than/one/token", ["more", "than", "one", "token"])
         check("/has/numbers/0/and/symbols/^", ["has", "numbers", "0", "and", "symbols", "^"])
@@ -742,33 +786,6 @@ class TestPathAddressing(unittest.TestCase):
         # XPATH 1.0 does not support double-quotes within double-quoted string. str literal can be "[^"]*"
         # Not validating no double-quotes within double-quoted string
         check('/a/mix["of""quotes\'does"]/not/work/well', ["a", 'mix["of""quotes\'does"]', "not", "work", "well"])
-
-    def test_create_xpath(self):
-        def check(tokens, xpath):
-            expected=xpath
-            actual=self.path_addressing.create_xpath(tokens)
-            self.assertEqual(expected, actual)
-
-        check([], "/")
-        check(["token"], "/token")
-        check(["more", "than", "one", "token"], "/more/than/one/token")
-        check(["multi", "tokens", "with", "empty", "last", "token", ""], "/multi/tokens/with/empty/last/token/")
-        check(["has", "numbers", "0", "and", "symbols", "^"], "/has/numbers/0/and/symbols/^")
-        check(["has[a='predicate']", "in", "the", "beginning"], "/has[a='predicate']/in/the/beginning")
-        check(["ha", "s[a='predicate']", "in", "the", "middle"], "/ha/s[a='predicate']/in/the/middle")
-        check(["ha", "s[a='predicate-in-the-end']"], "/ha/s[a='predicate-in-the-end']")
-        check(["it", "has[more='than'][one='predicate']", "somewhere"], "/it/has[more='than'][one='predicate']/somewhere")
-        check(["ha", "s[a='predicate\"with']", "double-quotes", "inside"], "/ha/s[a='predicate\"with']/double-quotes/inside")
-        check(["a", 'predicate[with="double"]', "quotes"], '/a/predicate[with="double"]/quotes')
-        check(['multiple["predicate"][with="double"]', "quotes"], '/multiple["predicate"][with="double"]/quotes')
-        check(['multiple["predicate"][with="double"]', "quotes"], '/multiple["predicate"][with="double"]/quotes')
-        check(["ha", 's[a="predicate\'with"]', "single-quote", "inside"], '/ha/s[a="predicate\'with"]/single-quote/inside')
-        # XPATH 1.0 does not support single-quote within single-quoted string. str literal can be '[^']*'
-        # Not validating no single-quote within single-quoted string
-        check(["a", "mix['of''quotes\"does']", "not", "work", "well"], "/a/mix['of''quotes\"does']/not/work/well", )
-        # XPATH 1.0 does not support double-quotes within double-quoted string. str literal can be "[^"]*"
-        # Not validating no double-quotes within double-quoted string
-        check(["a", 'mix["of""quotes\'does"]', "not", "work", "well"], '/a/mix["of""quotes\'does"]/not/work/well')
 
     def test_find_ref_paths__ref_is_the_whole_key__returns_ref_paths(self):
         # Arrange

--- a/tests/generic_config_updater/gutest_helpers.py
+++ b/tests/generic_config_updater/gutest_helpers.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import unittest
 from unittest.mock import MagicMock, Mock, call
+from generic_config_updater.patch_sorter import JsonMoveGroup
 
 class MockSideEffectDict:
     def __init__(self, map):
@@ -19,8 +20,52 @@ class MockSideEffectDict:
 
         return value
 
+    def side_effect_skiplastarg_func(self, *args):
+        arglist = [str(args[i]) for i in range(len(args)-1)]
+        key = tuple(arglist)
+        value = self.map.get(key)
+        if value is None:
+            raise ValueError(f"Given arguments were not found in arguments map.\n  Arguments: {key}\n  Map: {self.map}")
+
+        return value
+
+    def side_effect_skipfirstarg_func(self, *args):
+        arglist = [str(args[i+1]) for i in range(len(args)-1)]
+        key = tuple(arglist)
+        value = self.map.get(key)
+        if value is None:
+            raise ValueError(f"Given arguments were not found in arguments map.\n  Arguments: {key}\n  Map: {self.map}")
+
+        return value
+
+    def side_effect_jsonmovegroup_func(self, *args):
+        arglist = [str(arg) for arg in args]
+        key = tuple(arglist)
+        value = self.map.get(key)
+        if value is None:
+            raise ValueError(f"Given arguments were not found in arguments map.\n  Arguments: {key}\n  Map: {self.map}")
+
+        rv = []
+        for val in value:
+            rv.append(JsonMoveGroup(val))
+        return rv
+
+
 def create_side_effect_dict(map):
     return MockSideEffectDict(map).side_effect_func
+
+
+def create_side_effect_skiplastarg_dict(map):
+    return MockSideEffectDict(map).side_effect_skiplastarg_func
+
+
+def create_side_effect_skipfirstarg_dict(map):
+    return MockSideEffectDict(map).side_effect_skipfirstarg_func
+
+
+def create_side_effect_jsonmovegroup_dict(map):
+    return MockSideEffectDict(map).side_effect_jsonmovegroup_func
+
 
 class FilesLoader:
     def __init__(self):

--- a/tests/generic_config_updater/multiasic_change_applier_test.py
+++ b/tests/generic_config_updater/multiasic_change_applier_test.py
@@ -1,5 +1,6 @@
 import jsonpointer
 import unittest
+import copy
 from importlib import reload
 from unittest.mock import patch, MagicMock
 from generic_config_updater.generic_updater import extract_scope
@@ -161,7 +162,7 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
             except jsonpointer.JsonPointerException:
                 assert(not result)
 
-    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_default_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -178,12 +179,13 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         change = MagicMock()
 
         # Call the apply method with the change object
-        applier.apply(change)
+        current_config = copy.deepcopy(generic_config_updater.gu_common.get_config_db_as_json(scope=self))
+        current_config = applier.apply(current_config, change)
 
         # Assert ConfigDBConnector called with the correct namespace
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="")
 
-    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_given_scope(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -198,12 +200,13 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         change = MagicMock()
 
         # Call the apply method with the change object
-        applier.apply(change)
+        current_config = copy.deepcopy(generic_config_updater.gu_common.get_config_db_as_json(scope="asic0"))
+        current_config = applier.apply(current_config, change)
 
         # Assert ConfigDBConnector called with the correct scope
         mock_ConfigDBConnector.assert_called_once_with(use_unix_socket_path=True, namespace="asic0")
 
-    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_change_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -221,11 +224,12 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
 
         # Test the behavior when os.system fails
         with self.assertRaises(Exception) as context:
-            applier.apply(change)
+            current_config = copy.deepcopy(generic_config_updater.gu_common.get_config_db_as_json())
+            current_config = applier.apply(current_config, change)
 
         self.assertTrue('Failed to get running config' in str(context.exception))
 
-    @patch('generic_config_updater.change_applier.get_config_db_as_json', autospec=True)
+    @patch('generic_config_updater.gu_common.get_config_db_as_json', autospec=True)
     @patch('generic_config_updater.change_applier.ConfigDBConnector', autospec=True)
     def test_apply_patch_with_empty_tables_failure(self, mock_ConfigDBConnector, mock_get_running_config):
         # Setup mock for ConfigDBConnector
@@ -251,8 +255,10 @@ class TestMultiAsicChangeApplier(unittest.TestCase):
         # Prepare a change object or data that applier.apply would use, simulating a patch that requires non-empty tables
         change = MagicMock()
 
+        current_config = copy.deepcopy(generic_config_updater.gu_common.get_config_db_as_json())
+
         # Apply the patch
         try:
-            assert(applier.apply(change) != 0)
+            assert(applier.apply(current_config, change) is not None)
         except Exception:
             pass

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2,11 +2,12 @@ from collections import OrderedDict
 import jsonpatch
 import unittest
 from unittest.mock import MagicMock, Mock
-
 import generic_config_updater.patch_sorter as ps
-from .gutest_helpers import Files, create_side_effect_dict
+from .gutest_helpers import Files, create_side_effect_dict, create_side_effect_jsonmovegroup_dict, \
+                            create_side_effect_skiplastarg_dict
 from generic_config_updater.gu_common import ConfigWrapper, PatchWrapper, OperationWrapper, \
                                              GenericConfigUpdaterError, OperationType, JsonChange, PathAddressing
+from generic_config_updater.patch_sorter import JsonMoveGroup
 
 class TestDiff(unittest.TestCase):
     def test_apply_move__updates_current_config(self):
@@ -438,14 +439,14 @@ class TestMoveWrapper(unittest.TestCase):
 
         self.single_move_generator = Mock()
         self.single_move_generator.generate.side_effect = \
-            create_side_effect_dict({(str(self.any_diff),): [self.any_move]})
+            create_side_effect_jsonmovegroup_dict({(str(self.any_diff),): [self.any_move]})
 
         self.another_single_move_generator = Mock()
         self.another_single_move_generator.generate.side_effect = \
-            create_side_effect_dict({(str(self.any_diff),): [self.any_other_move1]})
+            create_side_effect_jsonmovegroup_dict({(str(self.any_diff),): [self.any_other_move1]})
 
         self.multiple_move_generator = Mock()
-        self.multiple_move_generator.generate.side_effect = create_side_effect_dict(
+        self.multiple_move_generator.generate.side_effect = create_side_effect_jsonmovegroup_dict(
             {(str(self.any_diff),): [self.any_move, self.any_other_move1, self.any_other_move2]})
 
         self.single_move_extender = Mock()
@@ -488,11 +489,11 @@ class TestMoveWrapper(unittest.TestCase):
             })
 
         self.fail_move_validator = Mock()
-        self.fail_move_validator.validate.side_effect = create_side_effect_dict(
+        self.fail_move_validator.validate.side_effect = create_side_effect_skiplastarg_dict(
             {(str(self.any_move), str(self.any_diff)): False})
 
         self.success_move_validator = Mock()
-        self.success_move_validator.validate.side_effect = create_side_effect_dict(
+        self.success_move_validator.validate.side_effect = create_side_effect_skiplastarg_dict(
             {(str(self.any_move), str(self.any_diff)): True})
 
     def test_ctor__assigns_values_correctly(self):
@@ -515,7 +516,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_generators = [self.single_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, [], [], [])
-        expected = [self.any_move]
+        expected = [JsonMoveGroup(self.any_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -527,7 +528,8 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_generators = [self.multiple_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, [], [], [])
-        expected = [self.any_move, self.any_other_move1, self.any_other_move2]
+        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_other_move1),
+                    JsonMoveGroup(self.any_other_move2)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -539,7 +541,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_generators = [self.single_move_generator, self.another_single_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, [], [], [])
-        expected = [self.any_move, self.any_other_move1]
+        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_other_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -551,7 +553,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_generators = [self.single_move_generator, self.single_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, [], [], [])
-        expected = [self.any_move]
+        expected = [JsonMoveGroup(self.any_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -563,7 +565,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_non_extendable_generators = [self.single_move_generator, self.another_single_move_generator]
         move_wrapper = ps.MoveWrapper([], move_non_extendable_generators, [], [])
-        expected = [self.any_move, self.any_other_move1]
+        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_other_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -575,7 +577,7 @@ class TestMoveWrapper(unittest.TestCase):
         # Arrange
         move_non_extendable_generators = [self.single_move_generator, self.single_move_generator]
         move_wrapper = ps.MoveWrapper([], move_non_extendable_generators, [], [])
-        expected = [self.any_move]
+        expected = [JsonMoveGroup(self.any_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -588,7 +590,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_non_extendable_generators = [self.single_move_generator]
         move_wrapper = ps.MoveWrapper(move_generators, move_non_extendable_generators, [], [])
-        expected = [self.any_move]
+        expected = [JsonMoveGroup(self.any_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -601,7 +603,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_extenders = [self.single_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [self.any_move, self.any_extended_move]
+        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_extended_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -614,7 +616,8 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_extenders = [self.multiple_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [self.any_move, self.any_extended_move, self.any_other_extended_move1, self.any_other_extended_move2]
+        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_extended_move),
+                    JsonMoveGroup(self.any_other_extended_move1), JsonMoveGroup(self.any_other_extended_move2)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -627,7 +630,8 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_extenders = [self.single_move_extender, self.another_single_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [self.any_move, self.any_extended_move, self.any_other_extended_move1]
+        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_extended_move),
+                    JsonMoveGroup(self.any_other_extended_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -640,7 +644,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator]
         move_extenders = [self.single_move_extender, self.single_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [self.any_move, self.any_extended_move]
+        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_extended_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -653,11 +657,11 @@ class TestMoveWrapper(unittest.TestCase):
         move_generators = [self.single_move_generator, self.another_single_move_generator]
         move_extenders = [self.mixed_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, [], move_extenders, [])
-        expected = [self.any_move,
-                    self.any_other_move1,
-                    self.any_extended_move,
-                    self.any_other_extended_move1,
-                    self.any_other_extended_move2]
+        expected = [JsonMoveGroup(self.any_move),
+                    JsonMoveGroup(self.any_other_move1),
+                    JsonMoveGroup(self.any_extended_move),
+                    JsonMoveGroup(self.any_other_extended_move1),
+                    JsonMoveGroup(self.any_other_extended_move2)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -670,7 +674,7 @@ class TestMoveWrapper(unittest.TestCase):
         move_non_extendable_generators = [self.single_move_generator, self.another_single_move_generator]
         move_extenders = [self.mixed_move_extender]
         move_wrapper = ps.MoveWrapper([], move_non_extendable_generators, move_extenders, [])
-        expected = [self.any_move, self.any_other_move1]
+        expected = [JsonMoveGroup(self.any_move), JsonMoveGroup(self.any_other_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -684,9 +688,9 @@ class TestMoveWrapper(unittest.TestCase):
         move_non_extendable_generators = [self.single_move_generator] # generates: any_move
         move_extenders = [self.mixed_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, move_non_extendable_generators, move_extenders, [])
-        expected = [self.any_move,
-                    self.any_other_move1,
-                    self.any_other_extended_move1]
+        expected = [JsonMoveGroup(self.any_move),
+                    JsonMoveGroup(self.any_other_move1),
+                    JsonMoveGroup(self.any_other_extended_move1)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -700,8 +704,8 @@ class TestMoveWrapper(unittest.TestCase):
         move_non_extendable_generators = [self.single_move_generator]
         move_extenders = [self.single_move_extender]
         move_wrapper = ps.MoveWrapper(move_generators, move_non_extendable_generators, move_extenders, [])
-        expected = [self.any_move,
-                    self.any_extended_move]
+        expected = [JsonMoveGroup(self.any_move),
+                    JsonMoveGroup(self.any_extended_move)]
 
         # Act
         actual = list(move_wrapper.generate(self.any_diff))
@@ -739,12 +743,12 @@ class TestMoveWrapper(unittest.TestCase):
         move_wrapper = ps.MoveWrapper([], [], [], move_validators)
 
         # Act and assert
-        self.assertTrue(move_wrapper.validate(self.any_move, self.any_diff))
+        self.assertTrue(move_wrapper.validate(JsonMoveGroup(self.any_move), self.any_diff))
 
     def test_simulate__applies_move(self):
         # Arrange
         diff = Mock()
-        diff.apply_move.side_effect = create_side_effect_dict({(str(self.any_move), ): self.any_diff})
+        diff.apply_move.side_effect = create_side_effect_skiplastarg_dict({(str(self.any_move), ): self.any_diff})
         move_wrapper = ps.MoveWrapper(None, None, None, None)
 
         # Act
@@ -870,7 +874,9 @@ class TestDeleteWholeConfigMoveValidator(unittest.TestCase):
     def setUp(self):
         self.operation_wrapper = OperationWrapper()
         self.validator = ps.DeleteWholeConfigMoveValidator()
-        self.any_diff = Mock()
+        self.any_current_config = Mock()
+        self.any_target_config = Mock()
+        self.any_diff = ps.Diff(self.any_current_config, self.any_target_config)
         self.any_non_whole_config_path = "/table1"
         self.whole_config_path = ""
 
@@ -898,7 +904,7 @@ class TestDeleteWholeConfigMoveValidator(unittest.TestCase):
         move = ps.JsonMove.from_operation(operation)
 
         # Act
-        actual = self.validator.validate(move, self.any_diff)
+        actual = self.validator.validate(JsonMoveGroup(move), self.any_diff, self.any_target_config)
 
         # Assert
         self.assertEqual(expected, actual)
@@ -921,7 +927,7 @@ class TestFullConfigMoveValidator(unittest.TestCase):
         validator = ps.FullConfigMoveValidator(config_wrapper)
 
         # Act and assert
-        self.assertFalse(validator.validate(self.any_move, self.any_diff))
+        self.assertFalse(validator.validate(JsonMoveGroup(self.any_move), self.any_diff, self.any_simulated_config))
 
     def test_validate__valid_config_db_after_applying_move__success(self):
         # Arrange
@@ -931,7 +937,7 @@ class TestFullConfigMoveValidator(unittest.TestCase):
         validator = ps.FullConfigMoveValidator(config_wrapper)
 
         # Act and assert
-        self.assertTrue(validator.validate(self.any_move, self.any_diff))
+        self.assertTrue(validator.validate(JsonMoveGroup(self.any_move), self.any_diff, self.any_simulated_config))
 
 class TestCreateOnlyMoveValidator(unittest.TestCase):
     def setUp(self):
@@ -1193,7 +1199,7 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
         diff = ps.Diff(current_config, target_config)
         move = ps.JsonMove.from_operation({"op":"add", "path":"/BGP_NEIGHBOR/10.0.0.57", "value": added_parent_value})
 
-        actual = self.validator.validate(move, diff)
+        actual = self.validator.validate(move, diff, move.apply(diff.current_config))
 
         self.assertEqual(expected, actual)
 
@@ -1205,7 +1211,7 @@ class TestCreateOnlyMoveValidator(unittest.TestCase):
         move = ps.JsonMove(diff, OperationType.REPLACE, current_config_tokens, target_config_tokens)
 
         # Act
-        actual = self.validator.validate(move, diff)
+        actual = self.validator.validate(move, diff, move.apply(diff.current_config))
 
         # Assert
         self.assertEqual(expected, actual)
@@ -1220,18 +1226,17 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # Arrange
         # CROPPED_CONFIG_DB_AS_JSON has dependencies between PORT and ACL_TABLE
         diff = ps.Diff(Files.EMPTY_CONFIG_DB, Files.CROPPED_CONFIG_DB_AS_JSON)
-        move = ps.JsonMove(diff, OperationType.ADD, [], [])
-
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, [], []))
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__add_full_config_no_dependencies__success(self):
         # Arrange
         diff = ps.Diff(Files.EMPTY_CONFIG_DB, Files.CONFIG_DB_NO_DEPENDENCIES)
-        move = ps.JsonMove(diff, OperationType.ADD, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, [], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__add_table_has_no_dependencies__success(self):
         # Arrange
@@ -1241,27 +1246,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
             {"op": "remove", "path":"/ACL_TABLE"}
         ]))
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.ADD, ["ACL_TABLE"], ["ACL_TABLE"])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, ["ACL_TABLE"], ["ACL_TABLE"]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
-
-    def test_validate__remove_full_config_has_dependencies__failure(self):
-        # Arrange
-        # CROPPED_CONFIG_DB_AS_JSON has dependencies between PORT and ACL_TABLE
-        diff = ps.Diff(Files.CROPPED_CONFIG_DB_AS_JSON, Files.EMPTY_CONFIG_DB)
-        move = ps.JsonMove(diff, OperationType.REMOVE, [], [])
-
-        # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
-
-    def test_validate__remove_full_config_no_dependencies__success(self):
-        # Arrange
-        diff = ps.Diff(Files.EMPTY_CONFIG_DB, Files.CONFIG_DB_NO_DEPENDENCIES)
-        move = ps.JsonMove(diff, OperationType.REMOVE, [], [])
-
-        # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__remove_table_has_no_dependencies__success(self):
         # Arrange
@@ -1270,10 +1258,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
             {"op": "remove", "path":"/ACL_TABLE"}
         ]))
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REMOVE, ["ACL_TABLE"])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["ACL_TABLE"]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__replace_whole_config_item_added_ref_added__failure(self):
         # Arrange
@@ -1285,10 +1273,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         ]))
 
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__replace_whole_config_item_removed_ref_removed__false(self):
         # Arrange
@@ -1300,10 +1288,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         ]))
 
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__replace_whole_config_item_same_ref_added__true(self):
         # Arrange
@@ -1314,10 +1302,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         ]))
 
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__replace_whole_config_item_same_ref_removed__true(self):
         # Arrange
@@ -1328,10 +1316,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         ]))
 
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__replace_whole_config_item_same_ref_same__true(self):
         # Arrange
@@ -1340,10 +1328,10 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         target_config = current_config
 
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__replace_list_item_different_location_than_target_and_no_deps__true(self):
         # Arrange
@@ -1371,10 +1359,59 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         diff = ps.Diff(current_config, target_config)
         # the target tokens point to location 0 which exist in target_config
         # but the replace operation is operating on location 1 in current_config
-        move = ps.JsonMove(diff, OperationType.REPLACE, ["VLAN", "Vlan100", "dhcp_servers", 1], ["VLAN", "Vlan100", "dhcp_servers", 0])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, ["VLAN", "Vlan100", "dhcp_servers", 1],
+                                         ["VLAN", "Vlan100", "dhcp_servers", 0]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
+
+    def test_validate_replace__calls_find_ref_paths_simulated_config_before_current_config(self):
+        """
+        _validate_replace must check added_paths/simulated_config FIRST, then deleted_paths/current_config.
+        This ordering lets find_ref_paths reuse the sy singleton already loaded with simulated_config
+        by FullConfigMoveValidator (via _currently_loaded_hash), saving one loadData call per REPLACE.
+        """
+        config_wrapper = ConfigWrapper()
+        mock_pa = MagicMock(spec=PathAddressing)
+
+        # Track which config is passed to find_ref_paths in call order
+        configs_seen = []
+
+        def track_find_ref_paths(paths, config, reload_config=True):
+            configs_seen.append(config)
+            return []  # no refs → validation passes
+        mock_pa.find_ref_paths = MagicMock(side_effect=track_find_ref_paths)
+        mock_pa.create_path = PathAddressing.create_path
+
+        validator = ps.NoDependencyMoveValidator(mock_pa, config_wrapper)
+
+        # Patch _get_paths on the validator instance (not on mock_pa — _get_paths is a method
+        # on NoDependencyMoveValidator, not on PathAddressing)
+        deleted_paths = ["/PORT/Ethernet0"]
+        added_paths = ["/PORT/Ethernet4"]
+        validator._get_paths = MagicMock(return_value=(deleted_paths, added_paths))
+
+        current_config = {"PORT": {"Ethernet0": {"lanes": "0"}}}
+        simulated_config = {"PORT": {"Ethernet4": {"lanes": "4"}}}
+        diff = ps.Diff(current_config, simulated_config)
+
+        # Create a move mock with the right attributes, wrapped in a group mock
+        # that is iterable (validate() does `for move in group:`)
+        inner_move = MagicMock()
+        inner_move.op_type = OperationType.REPLACE
+        inner_move.path = ""
+        group = MagicMock()
+        group.__iter__ = MagicMock(return_value=iter([inner_move]))
+
+        validator.validate(group, diff, simulated_config)
+
+        # Assert: simulated_config must be checked first (for added_paths),
+        # then current_config (for deleted_paths)
+        self.assertEqual(len(configs_seen), 2, "find_ref_paths should be called exactly twice")
+        self.assertIs(configs_seen[0], simulated_config,
+                      "First find_ref_paths call must use simulated_config (for added_paths)")
+        self.assertIs(configs_seen[1], current_config,
+                      "Second find_ref_paths call must use current_config (for deleted_paths)")
 
     def prepare_config(self, config, patch):
         return patch.apply(config)
@@ -1389,110 +1426,110 @@ class TestNoEmptyTableMoveValidator(unittest.TestCase):
         current_config = {"some_table":{"key1":"value1", "key2":"value2"}}
         target_config = {"some_table":{"key1":"value1", "key2":"value22"}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, ["some_table", "key1"], ["some_table", "key1"])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, ["some_table", "key1"], ["some_table", "key1"]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__change_but_no_empty_table__success(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1", "key2":"value2"}}
         target_config = {"some_table":{"key1":"value1", "key2":"value22"}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, ["some_table", "key2"], ["some_table", "key2"])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, ["some_table", "key2"], ["some_table", "key2"]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__single_empty_table__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1", "key2":"value2"}}
         target_config = {"some_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, ["some_table"], ["some_table"])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, ["some_table"], ["some_table"]))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__whole_config_replace_single_empty_table__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1", "key2":"value2"}}
         target_config = {"some_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__whole_config_replace_mix_of_empty_and_non_empty__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"some_table":{"key1":"value1"}, "other_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__whole_config_multiple_empty_tables__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"some_table":{}, "other_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REPLACE, [], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__remove_key_empties_a_table__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"some_table":{"key1":"value1"}, "other_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REMOVE, ["other_table", "key2"], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["other_table", "key2"], []))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__remove_key_but_table_has_other_keys__success(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2", "key3":"value3"}}
         target_config = {"some_table":{"key1":"value1"}, "other_table":{"key3":"value3"}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REMOVE, ["other_table", "key2"], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["other_table", "key2"], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__remove_whole_table__success(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"some_table":{"key1":"value1"}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.REMOVE, ["other_table"], [])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["other_table"], []))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__add_empty_table__failure(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"new_table":{}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.ADD, ["new_table"], ["new_table"])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, ["new_table"], ["new_table"]))
 
         # Act and assert
-        self.assertFalse(self.validator.validate(move, diff))
+        self.assertFalse(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def test_validate__add_non_empty_table__success(self):
         # Arrange
         current_config = {"some_table":{"key1":"value1"}, "other_table":{"key2":"value2"}}
         target_config = {"new_table":{"key3":"value3"}}
         diff = ps.Diff(current_config, target_config)
-        move = ps.JsonMove(diff, OperationType.ADD, ["new_table"], ["new_table"])
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, ["new_table"], ["new_table"]))
 
         # Act and assert
-        self.assertTrue(self.validator.validate(move, diff))
+        self.assertTrue(self.validator.validate(move, diff, move.apply(diff.current_config)))
 
 class TestRequiredValueMoveValidator(unittest.TestCase):
     def setUp(self):
@@ -1527,12 +1564,12 @@ class TestRequiredValueMoveValidator(unittest.TestCase):
         # Arrange
         expected = test_case['expected']
         current_config = test_case['config']
-        move = test_case['move']
+        move = JsonMoveGroup(test_case['move'])
         target_config = test_case.get('target_config', move.apply(current_config))
         diff = ps.Diff(current_config, target_config)
 
         # Act and Assert
-        self.assertEqual(expected, self.validator.validate(move, diff))
+        self.assertEqual(expected, self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def _get_critical_port_change_test_cases(self):
         # port-up  status-changing  under-port  port-exist  verdict
@@ -1991,12 +2028,12 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
         # Arrange
         expected = test_case['expected']
         current_config = test_case['config']
-        move = test_case['move']
+        move = JsonMoveGroup(test_case['move'])
         target_config = test_case.get('target_config', move.apply(current_config))
         diff = ps.Diff(current_config, target_config)
 
         # Act and Assert
-        self.assertEqual(expected, self.validator.validate(move, diff))
+        self.assertEqual(expected, self.validator.validate(move, diff, move.apply(diff.current_config)))
 
     def _apply_operations(self, config, operations):
         return jsonpatch.JsonPatch(operations).apply(config)
@@ -2078,7 +2115,8 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
 
 class TestTableLevelMoveGenerator(unittest.TestCase):
     def setUp(self):
-        self.generator = ps.TableLevelMoveGenerator()
+        path_addressing = PathAddressing()
+        self.generator = ps.TableLevelMoveGenerator(path_addressing)
 
     def test_generate__tables_in_current_but_not_target__tables_deleted_moves(self):
         self.verify(current = {"ExistingTable": {}, "NonExistingTable1": {}, "NonExistingTable2": {}},
@@ -2115,12 +2153,15 @@ class TestTableLevelMoveGenerator(unittest.TestCase):
                           moves)
 
     def verify_moves(self, ops, moves):
-        moves_ops = [list(move.patch)[0] for move in moves]
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.get_jsonpatch())
         self.assertCountEqual(ops, moves_ops)
 
 class TestKeyLevelMoveGenerator(unittest.TestCase):
     def setUp(self):
-        self.generator = ps.KeyLevelMoveGenerator()
+        path_addressing = PathAddressing()
+        self.generator = ps.KeyLevelMoveGenerator(path_addressing)
 
     def test_generate__keys_in_current_but_not_target__keys_deleted_moves(self):
         self.verify(current = {
@@ -2197,8 +2238,95 @@ class TestKeyLevelMoveGenerator(unittest.TestCase):
                           moves)
 
     def verify_moves(self, ops, moves):
-        moves_ops = [list(move.patch)[0] for move in moves]
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.get_jsonpatch())
         self.assertCountEqual(ops, moves_ops)
+
+
+class TestBulkLeafListMoveGenerator(unittest.TestCase):
+    def setUp(self):
+        path_addressing = PathAddressing()
+        self.generator = ps.BulkLeafListMoveGenerator(path_addressing)
+
+    def test_generate__leaf_list_items_removed__single_replace_move(self):
+        """Removing items from a leaf-list should produce one REPLACE move."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4", "Ethernet8"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet8"], "type": "MIRROR"}}},
+            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports",
+                     "value": ["Ethernet8"]}])
+
+    def test_generate__leaf_list_items_added__single_replace_move(self):
+        """Adding items to a leaf-list should produce one REPLACE move."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4", "Ethernet8"], "type": "MIRROR"}}},
+            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports",
+                     "value": ["Ethernet0", "Ethernet4", "Ethernet8"]}])
+
+    def test_generate__leaf_list_unchanged__no_moves(self):
+        """Identical leaf-lists should produce no moves."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
+            ex_ops=[])
+
+    def test_generate__non_list_fields_differ__no_moves(self):
+        """Non-list field changes should not produce moves from this generator."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"], "type": "L3"}}},
+            ex_ops=[])
+
+    def test_generate__list_of_dicts__no_moves(self):
+        """Lists of dicts (not leaf-lists) should be skipped."""
+        self.verify(
+            current={"TABLE": {"KEY": {"items": [{"a": 1}, {"b": 2}]}}},
+            target={"TABLE": {"KEY": {"items": [{"a": 1}]}}},
+            ex_ops=[])
+
+    def test_generate__list_only_in_current__no_moves(self):
+        """List exists in current but not target — not a REPLACE, skip."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR"}}},
+            ex_ops=[])
+
+    def test_generate__list_only_in_target__no_moves(self):
+        """List exists in target but not current — handled by other generators, skip."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"type": "MIRROR", "ports": ["Ethernet0"]}}},
+            ex_ops=[])
+
+    def test_generate__leaf_list_all_items_removed__single_replace_move(self):
+        """Removing all items from a leaf-list should produce one REPLACE with empty list."""
+        self.verify(
+            current={"ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0", "Ethernet4"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {"EVERFLOW": {"ports": [], "type": "MIRROR"}}},
+            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/EVERFLOW/ports", "value": []}])
+
+    def test_generate__multiple_tables_with_leaf_lists__multiple_moves(self):
+        """Multiple differing leaf-lists should each get a REPLACE move."""
+        self.verify(
+            current={"ACL_TABLE": {
+                "T1": {"ports": ["Ethernet0", "Ethernet4"], "type": "L3"},
+                "T2": {"ports": ["Ethernet8", "Ethernet12"], "type": "MIRROR"}}},
+            target={"ACL_TABLE": {
+                "T1": {"ports": ["Ethernet0"], "type": "L3"},
+                "T2": {"ports": ["Ethernet12"], "type": "MIRROR"}}},
+            ex_ops=[{"op": "replace", "path": "/ACL_TABLE/T1/ports", "value": ["Ethernet0"]},
+                    {"op": "replace", "path": "/ACL_TABLE/T2/ports", "value": ["Ethernet12"]}])
+
+    def verify(self, current, target, ex_ops):
+        diff = ps.Diff(current, target)
+        moves = list(self.generator.generate(diff))
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.get_jsonpatch())
+        self.assertCountEqual(ex_ops, moves_ops)
+
 
 class TestLowLevelMoveGenerator(unittest.TestCase):
     def setUp(self):
@@ -2436,7 +2564,9 @@ class TestLowLevelMoveGenerator(unittest.TestCase):
         self.verify_moves(expected, actual)
 
     def verify_moves(self, ops, moves):
-        moves_ops = [list(move.patch)[0] for move in moves]
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.get_jsonpatch())
         self.assertCountEqual(ops, moves_ops)
 
     def get_diff(self, target_config_ops = None, current_config_ops = None):
@@ -2528,7 +2658,9 @@ class RemoveCreateOnlyDependencyMoveGenerator(unittest.TestCase):
                           moves)
 
     def verify_moves(self, ops, moves):
-        moves_ops = [list(move.patch)[0] for move in moves]
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.get_jsonpatch())
         self.assertCountEqual(ops, moves_ops)
 
 class TestRequiredValueMoveExtender(unittest.TestCase):
@@ -2782,7 +2914,9 @@ class TestRequiredValueMoveExtender(unittest.TestCase):
         self._verify_moves(expected, actual)
 
     def _verify_moves(self, ex_ops, moves):
-        moves_ops = [list(move.patch)[0] for move in moves]
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.patch)
         self.assertCountEqual(ex_ops, moves_ops)
 
     def _apply_operations(self, config, operations):
@@ -3113,7 +3247,9 @@ class TestUpperLevelMoveExtender(unittest.TestCase):
         self.verify_moves(ex_ops, moves)
 
     def verify_moves(self, ex_ops, moves):
-        moves_ops = [list(move.patch)[0] for move in moves]
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.patch)
         self.assertCountEqual(ex_ops, moves_ops)
 
 class TestDeleteInsteadOfReplaceMoveExtender(unittest.TestCase):
@@ -3178,7 +3314,9 @@ class TestDeleteInsteadOfReplaceMoveExtender(unittest.TestCase):
         self.verify_moves(ex_ops, moves)
 
     def verify_moves(self, ex_ops, moves):
-        moves_ops = [list(move.patch)[0] for move in moves]
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.patch)
         self.assertCountEqual(ex_ops, moves_ops)
 
 class DeleteRefsMoveExtender(unittest.TestCase):
@@ -3242,7 +3380,9 @@ class DeleteRefsMoveExtender(unittest.TestCase):
         self.verify_moves(ex_ops, moves)
 
     def verify_moves(self, ex_ops, moves):
-        moves_ops = [list(move.patch)[0] for move in moves]
+        moves_ops = []
+        for move in moves:
+            moves_ops.extend(move.patch)
         self.assertCountEqual(ex_ops, moves_ops)
 
 class TestSortAlgorithmFactory(unittest.TestCase):
@@ -3261,7 +3401,11 @@ class TestSortAlgorithmFactory(unittest.TestCase):
         factory = ps.SortAlgorithmFactory(OperationWrapper(), config_wrapper, PathAddressing(config_wrapper))
         expected_generators = [ps.RemoveCreateOnlyDependencyMoveGenerator,
                                ps.LowLevelMoveGenerator]
-        expected_non_extendable_generators = [ps.KeyLevelMoveGenerator]
+        expected_non_extendable_generators = [ps.BulkKeyLevelMoveGenerator,
+                                              ps.KeyLevelMoveGenerator,
+                                              ps.BulkKeyGroupLowLevelMoveGenerator,
+                                              ps.BulkLowLevelMoveGenerator,
+                                              ps.BulkLeafListMoveGenerator]
         expected_extenders = [ps.RequiredValueMoveExtender,
                               ps.UpperLevelMoveExtender,
                               ps.DeleteInsteadOfReplaceMoveExtender,
@@ -3332,6 +3476,7 @@ class TestPatchSorter(unittest.TestCase):
             simulated_config = change.apply(simulated_config)
             is_valid, error = self.config_wrapper.validate_config_db_config(simulated_config)
             self.assertTrue(is_valid, f"Change will produce invalid config. Error: {error}")
+
         self.assertEqual(target_config, simulated_config)
 
     def test_patch_sorter_failure(self):
@@ -3378,7 +3523,7 @@ class TestPatchSorter(unittest.TestCase):
         any_patch = Files.SINGLE_OPERATION_CONFIG_DB_PATCH
         target_config = any_patch.apply(current_config)
         sort_algorithm = Mock()
-        sort_algorithm.sort = lambda diff: [ps.JsonMove(diff, OperationType.REPLACE, [], [])]
+        sort_algorithm.sort = lambda diff: [JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))]
         patch_sorter = self.create_patch_sorter(current_config, sort_algorithm)
         expected = [JsonChange(jsonpatch.JsonPatch([OperationWrapper().create(OperationType.REPLACE, "", target_config)]))]
 

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1233,7 +1233,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
             "ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"]}}
         }
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.ADD, ["ACL_TABLE"], ["ACL_TABLE"]))
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.ADD, ["ACL_TABLE"], ["ACL_TABLE"]))
         simulated_config = move.apply(diff.current_config)
 
         self.validator.path_addressing.find_ref_paths = Mock(
@@ -1242,7 +1242,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # Must not raise; the move is rejected so the DFS can backtrack. Pin the exact arguments so a
         # regression swapping simulated_config <-> diff.current_config in the ADD branch is caught
         # (simulated_config is value-distinct from current_config here: it carries the added ACL_TABLE).
-        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.assertFalse(self.validator.validate(move, diff, simulated_config))
         self.validator.path_addressing.find_ref_paths.assert_called_once_with(
             ["/ACL_TABLE"], simulated_config, reload_config=True)
 
@@ -1257,7 +1257,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
             "ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"]}}
         }
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REPLACE, [], []))
         simulated_config = move.apply(diff.current_config)
 
         self.validator.path_addressing.find_ref_paths = Mock(
@@ -1266,7 +1266,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         # Must not raise; the move is rejected so the DFS can backtrack. Pin the config argument so a
         # regression routing REPLACE added_paths through diff.current_config instead of the simulated
         # config is caught (the two configs are value-distinct: simulated carries the added ACL_TABLE).
-        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.assertFalse(self.validator.validate(move, diff, simulated_config))
         self.validator.path_addressing.find_ref_paths.assert_called_once_with(
             ["/ACL_TABLE"], simulated_config, reload_config=True)
 
@@ -1280,7 +1280,7 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         }
         target_config = {"PORT": {"Ethernet0": {}}}
         diff = ps.Diff(current_config, target_config)
-        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REMOVE, ["ACL_TABLE"]))
+        move = JsonMoveGroup(ps.JsonMove(diff, OperationType.REMOVE, ["ACL_TABLE"]))
         simulated_config = move.apply(diff.current_config)
 
         self.validator.path_addressing.find_ref_paths = Mock(
@@ -2133,14 +2133,14 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
             }
         }
 
-        move = JsonMoveGroup("", Mock())
+        move = JsonMoveGroup(Mock())
         diff = ps.Diff(current_config, target_config)
 
         self.validator.path_addressing.find_ref_paths = Mock(
             side_effect=ValueError("'Ethernet312' is not in list"))
 
         # Must not raise; the move is rejected so the DFS can backtrack.
-        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.assertFalse(self.validator.validate(move, diff, simulated_config))
         # Pin the assertion to the code path under test: the rejection must come from the guarded
         # find_ref_paths call raising, resolved against the simulated (intermediate) config. Asserting
         # the exact arguments also catches a regression that swapped simulated_config <-> current_config.
@@ -2169,14 +2169,14 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
             }
         }
 
-        move = JsonMoveGroup("", Mock())
+        move = JsonMoveGroup(Mock())
         diff = ps.Diff(current_config, target_config)
 
         self.validator.path_addressing.find_ref_paths = Mock(
             side_effect=KeyError("ACL_TABLE"))
 
         # Must not raise; the move is rejected so the DFS can backtrack.
-        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.assertFalse(self.validator.validate(move, diff, simulated_config))
         self.validator.path_addressing.find_ref_paths.assert_called_once_with(
             "/PORT/Ethernet312", simulated_config, reload_config=True)
 
@@ -3647,7 +3647,11 @@ class TestPatchSorter(unittest.TestCase):
 
         actual_changes = sorter.sort(patch)
 
-        if not skip_exact_change_list_match:
+        # Honor per-fixture skip flag for cases whose expected patch sequence pinned a specific
+        # move ordering. #4335 (part 6) legitimately changes exploration order for some multi-table
+        # patches; the target_config equality check below still verifies functional correctness.
+        per_case_skip = data.get("skip_exact_change_list_match", False)
+        if not skip_exact_change_list_match and not per_case_skip:
             self.assertEqual(expected_changes, actual_changes)
 
         target_config = patch.apply(current_config)

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -2641,8 +2641,20 @@ class RemoveCreateOnlyDependencyMoveGenerator(unittest.TestCase):
         moves = list(self.generator.generate(diff))
 
         # Assert
+
+        # This is a proper output even though it looks wrong.
+        # Due to logic in the generator to ensure it removes the exact referenced
+        # leaves for dependents, then the CreateOnly path, followed by the parents
+        # of the dependent paths.  Since this is a generator called by DFS it will
+        # be called recursively so the parent may not ever be removed in practice.
+        # Also since it is recursive and starts over, in practice if it did need
+        # to delete the parent path, it would emit another delete of the
+        # create-only attribute parent.
         self.verify_moves([{'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports/0'},
-                           {'op': 'remove', 'path': '/VLAN_MEMBER/Vlan100|Ethernet0'}],
+                           {'op': 'remove', 'path': '/VLAN_MEMBER/Vlan100|Ethernet0'},
+                           {'op': 'remove', 'path': '/PORT/Ethernet0'},
+                           {'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports'},
+                           {'op': 'remove', 'path': '/VLAN_MEMBER'}],
                           moves)
 
     def test_generate__dpb_1_to_4_example(self):
@@ -2653,8 +2665,20 @@ class RemoveCreateOnlyDependencyMoveGenerator(unittest.TestCase):
         moves = list(self.generator.generate(diff))
 
         # Assert
-        self.verify_moves([{'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports/0'},
-                           {'op': 'remove', 'path': '/VLAN_MEMBER/Vlan100|Ethernet0'}],
+
+        # This is a proper output even though it looks wrong on a couple of fronts.
+        # Due to logic in the generator to ensure it doesn't create empty tables, it
+        # will remove the parent if it removed the last entry in the table.  In this
+        # case in each of the tables we are removing the only entry.  Then the repetition
+        # is due to logic to remove the parent of a dependent if the prior generator
+        # failed to validate, which ends up resolving to the same path as the original
+        # due to the no-empty-table logic.  Since no validators are run we see the same
+        # output twice.
+        self.verify_moves([{'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports'},
+                           {'op': 'remove', 'path': '/VLAN_MEMBER'},
+                           {'op': 'remove', 'path': '/PORT'},
+                           {'op': 'remove', 'path': '/ACL_TABLE/NO-NSW-PACL-V4/ports'},
+                           {'op': 'remove', 'path': '/VLAN_MEMBER'}],
                           moves)
 
     def verify_moves(self, ops, moves):
@@ -3399,9 +3423,9 @@ class TestSortAlgorithmFactory(unittest.TestCase):
         # Arrange
         config_wrapper = ConfigWrapper()
         factory = ps.SortAlgorithmFactory(OperationWrapper(), config_wrapper, PathAddressing(config_wrapper))
-        expected_generators = [ps.RemoveCreateOnlyDependencyMoveGenerator,
-                               ps.LowLevelMoveGenerator]
-        expected_non_extendable_generators = [ps.BulkKeyLevelMoveGenerator,
+        expected_generators = [ps.LowLevelMoveGenerator]
+        expected_non_extendable_generators = [ps.RemoveCreateOnlyDependencyMoveGenerator,
+                                              ps.BulkKeyLevelMoveGenerator,
                                               ps.KeyLevelMoveGenerator,
                                               ps.BulkKeyGroupLowLevelMoveGenerator,
                                               ps.BulkLowLevelMoveGenerator,

--- a/tests/generic_config_updater/patch_sorter_test.py
+++ b/tests/generic_config_updater/patch_sorter_test.py
@@ -1222,6 +1222,78 @@ class TestNoDependencyMoveValidator(unittest.TestCase):
         path_addressing = ps.PathAddressing(config_wrapper)
         self.validator = ps.NoDependencyMoveValidator(path_addressing, config_wrapper)
 
+    def test_validate__unresolvable_ref_in_simulated_config__add_rejected(self):
+        # A dangling leafref in the transient simulated intermediate config makes find_ref_paths
+        # raise ValueError. For a simulated-config-facing check (ADD here), the validator must reject
+        # the move (return False) so the sort backtracks, rather than letting the exception abort the
+        # whole sort.
+        current_config = {"PORT": {"Ethernet0": {}}}
+        target_config = {
+            "PORT": {"Ethernet0": {}},
+            "ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"]}}
+        }
+        diff = ps.Diff(current_config, target_config)
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.ADD, ["ACL_TABLE"], ["ACL_TABLE"]))
+        simulated_config = move.apply(diff.current_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=ValueError("'Ethernet0' is not in list"))
+
+        # Must not raise; the move is rejected so the DFS can backtrack. Pin the exact arguments so a
+        # regression swapping simulated_config <-> diff.current_config in the ADD branch is caught
+        # (simulated_config is value-distinct from current_config here: it carries the added ACL_TABLE).
+        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            ["/ACL_TABLE"], simulated_config, reload_config=True)
+
+    def test_validate__unresolvable_ref_in_simulated_config__replace_rejected(self):
+        # REPLACE is the operation type for a PORT breakout (rewriting lanes while an ACL reference
+        # lingers). _validate_replace validates added_paths against the simulated intermediate config,
+        # so an unresolvable reference there (KeyError here, e.g. a table with no YANG model) must
+        # reject the move rather than aborting the sort.
+        current_config = {"PORT": {"Ethernet0": {}}}
+        target_config = {
+            "PORT": {"Ethernet0": {}},
+            "ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"]}}
+        }
+        diff = ps.Diff(current_config, target_config)
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REPLACE, [], []))
+        simulated_config = move.apply(diff.current_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=KeyError("ACL_TABLE"))
+
+        # Must not raise; the move is rejected so the DFS can backtrack. Pin the config argument so a
+        # regression routing REPLACE added_paths through diff.current_config instead of the simulated
+        # config is caught (the two configs are value-distinct: simulated carries the added ACL_TABLE).
+        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            ["/ACL_TABLE"], simulated_config, reload_config=True)
+
+    def test_validate__value_error_on_current_config__propagates(self):
+        # A check against diff.current_config (a valid committed state) is not simulated, so a
+        # ValueError from find_ref_paths signals a genuine schema error and must propagate rather
+        # than being silently swallowed as a move rejection.
+        current_config = {
+            "PORT": {"Ethernet0": {}},
+            "ACL_TABLE": {"EVERFLOW": {"ports": ["Ethernet0"]}}
+        }
+        target_config = {"PORT": {"Ethernet0": {}}}
+        diff = ps.Diff(current_config, target_config)
+        move = JsonMoveGroup("", ps.JsonMove(diff, OperationType.REMOVE, ["ACL_TABLE"]))
+        simulated_config = move.apply(diff.current_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=ValueError("Keys in configDb not matching keys in SonicYang"))
+
+        with self.assertRaises(ValueError):
+            self.validator.validate(move, diff, simulated_config)
+        # Pin that the REMOVE validation ran against diff.current_config (unguarded), not
+        # simulated_config: the re-raise must be the guaranteed-current-config path, not a lucky
+        # raise that a config swap could mask. Configs are value-distinct (current has ACL_TABLE).
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            ["/ACL_TABLE"], diff.current_config, reload_config=True)
+
     def test_validate__add_full_config_has_dependencies__failure(self):
         # Arrange
         # CROPPED_CONFIG_DB_AS_JSON has dependencies between PORT and ACL_TABLE
@@ -2023,6 +2095,90 @@ class RemoveCreateOnlyDependencyMoveValidator(unittest.TestCase):
         for test_case_name in test_cases:
             with self.subTest(name=test_case_name):
                 self._run_single_test(test_cases[test_case_name])
+
+    def test_validate__unresolvable_ref_in_simulated_config__move_rejected(self):
+        # A create-only PORT field change (breakout rewriting lanes) can transiently
+        # remove the port from a multi-member leaf-list (e.g. ACL_TABLE.ports) in the simulated
+        # intermediate config while a leafref to it is still present. Resolving that dangling
+        # leafref raises ValueError ("'<port>' is not in list"). The validator must treat this as
+        # an invalid intermediate move (return False) so the sort backtracks, rather than letting
+        # the exception propagate and abort the whole sort.
+        current_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305,306,307,308,309,310,311,312", "admin_status": "up"}
+            },
+            "ACL_TABLE": {
+                "DATAACL": {"type": "L3", "ports": ["Ethernet312", "Ethernet280"]}
+            }
+        }
+        target_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305", "admin_status": "up"}
+            },
+            "ACL_TABLE": {
+                "DATAACL": {"type": "L3", "ports": ["Ethernet280"]}
+            }
+        }
+        # The transient intermediate config the sorter is validating: Ethernet312's create-only
+        # 'lanes' field has already been rewritten toward the target, but the ACL_TABLE leafref to
+        # it has not been removed yet, so the reference is momentarily dangling. Resolving it raises
+        # ValueError. Kept value-distinct from current_config (different lanes) so the argument
+        # assertion below would catch a regression that passed current_config to find_ref_paths.
+        simulated_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305", "admin_status": "up"}
+            },
+            "ACL_TABLE": {
+                "DATAACL": {"type": "L3", "ports": ["Ethernet312", "Ethernet280"]}
+            }
+        }
+
+        move = JsonMoveGroup("", Mock())
+        diff = ps.Diff(current_config, target_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=ValueError("'Ethernet312' is not in list"))
+
+        # Must not raise; the move is rejected so the DFS can backtrack.
+        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        # Pin the assertion to the code path under test: the rejection must come from the guarded
+        # find_ref_paths call raising, resolved against the simulated (intermediate) config. Asserting
+        # the exact arguments also catches a regression that swapped simulated_config <-> current_config.
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            "/PORT/Ethernet312", simulated_config, reload_config=True)
+
+    def test_validate__keyerror_in_simulated_config__move_rejected(self):
+        # find_ref_paths also raises KeyError (not just ValueError) when a referenced path's table
+        # has no YANG model in the simulated intermediate config. The guard must treat that the same
+        # way as an unresolvable reference: reject the move so the sort backtracks, not abort it.
+        current_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305,306,307,308,309,310,311,312", "admin_status": "up"}
+            }
+        }
+        target_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305", "admin_status": "up"}
+            }
+        }
+        # Value-distinct from current_config (lanes already rewritten toward the target) so the
+        # argument assertion below catches a regression that passed current_config instead.
+        simulated_config = {
+            "PORT": {
+                "Ethernet312": {"lanes": "305", "admin_status": "up"}
+            }
+        }
+
+        move = JsonMoveGroup("", Mock())
+        diff = ps.Diff(current_config, target_config)
+
+        self.validator.path_addressing.find_ref_paths = Mock(
+            side_effect=KeyError("ACL_TABLE"))
+
+        # Must not raise; the move is rejected so the DFS can backtrack.
+        self.assertFalse(self.validator.validate(move, diff, simulated_config)[0])
+        self.validator.path_addressing.find_ref_paths.assert_called_once_with(
+            "/PORT/Ethernet312", simulated_config, reload_config=True)
 
     def _run_single_test(self, test_case):
         # Arrange


### PR DESCRIPTION
## Summary

Backports upstream sonic-utilities `#3831` (GCU perf refactor) to `202405` in 8 parts:

- **Part 1/N** — Config-threading refactor (fetch config once, thread through ChangeApplier)
- **Part 2/N** — PathAddressing xpath cache + batch find_ref_paths
- **Part 3/N** — patch_sorter: JsonMoveGroup + Bulk generators + validator refactor
- **Part 4/N** — Fix-up (dangling caller, missing imports, test fixtures)
- **Part 5/N** — Backport upstream #4118 (remove direct libyang dependency in `gu_common.find_ref_paths`)
- **Part 6/N** — Backport upstream #4335 (plan-aware `RemoveCreateOnlyDependencyMoveGenerator` — resolves the 400G DFS-explosion caveat below)
- **Part 7/N** — Backport upstream #4668 (safety guard in `_validate_member` for create-only leaf-list)
- **Part 8/N** — Wire `BulkLeafListMoveGenerator` into `SortAlgorithmFactory.move_non_extendable_generators` + test-fixture adaptations (part 6 commit message stated this was re-added, but the wiring edit did not land — this restores it)

Diff vs `Azure/sonic-utilities.msft:202412` for ported prod files:
- `change_applier.py`, `patch_sorter.py`: 0 (identical)
- `gu_common.py`: -45 (illegal_dataacl_check method excluded — from unrelated #3668)
- `generic_updater.py`: -29 (skip_sort_tables + extract_scope multi-ASIC guard excluded — out of scope)

**Requires coordinating buildimage-msft PR #2733 (Layers 2+3) to merge first** — without it, GCU init hits `AttributeError: 'SonicYang' object has no attribute 'find_schema_dependencies'`.

## Update — 400G caveat resolved

The prior "Known caveat — 400G config-apply" section (DFS explosion in `RemoveCreateOnlyDependencyMoveValidator._validate_member` on 400G port-add) is **resolved by part 6 (backport of upstream #4335)**, which replaces the suboptimal `RemoveCreateOnlyDependencyMoveGenerator` with a plan-aware generator. Verified on the same DUT with the same `C_400g_config_noBufferPG.json` fixture: 400G dry-run now completes in **27 s / 25 moves** (3 consecutive runs: 27s, 26s, 26s). No hangs, no `KeyError`, no CPU pegging.

## Cherry-pick provenance

**Not a clean cherry-pick.** 202405's GCU has diverged from master — different method signatures, class structure and call sites — so `git cherry-pick` fails on most of these commits. Each upstream change was re-expressed against this branch: same logic, adapted to 202405's API. **No new logic is introduced.**

Parts 1–4 and 8 come from upstream [#3831](https://github.com/sonic-net/sonic-utilities/pull/3831) (merge `bd3de9da`); part 5 from [#4118](https://github.com/sonic-net/sonic-utilities/pull/4118) (`4b787b0f`); part 6 from [#4335](https://github.com/sonic-net/sonic-utilities/pull/4335) (`1580ccce`); part 7 from [#4668](https://github.com/sonic-net/sonic-utilities/pull/4668) (`0552d0d2`). The two review-driven commits are `1030de244` (restores the `scope` arg — the fixed line is identical to master `gu_common.py:215`) and `e830cc965` (master's test that catches it, from [#4219](https://github.com/sonic-net/sonic-utilities/pull/4219) `2e9e81c1`).

Net convergence vs master `1462eff8` — differing lines drop from **2063 → 491 (76% closed)**: `change_applier.py` 51→**0** (now byte-identical), `gu_common.py` 771→74, `patch_sorter.py` 1084→266, `generic_updater.py` 157→151.

Intentionally left out (none perf-related): master's path-trace/diagnostics feature (`trace_io`, `PatchSorterPath`, `(bool, reason)` validator returns), `list_checkpoints(includes_time)`, the multi-ASIC guard in `extract_scope`, `illegal_dataacl_check` (#3668), and `loadData(quiet=True)` (#4482 — needs a sonic-yang-mgmt kwarg 202405 lacks).


## Correctness / non-perf testing done (fresh run against parts 1-8)

### Full GCU unit-test suite (every file in `tests/generic_config_updater/`)

**409 passed + 81 subtests passed = 490 test cases, 0 failed** (26.44 s)

| Test file | Result |
|---|---|
| `gcu_feature_patch_application_test.py` | 2 passed, 2 subtests |
| `generic_updater_test.py` | 39 passed |
| `gu_common_test.py` | 74 passed |
| `main_test.py` | 88 passed |
| `multiasic_change_applier_test.py` | 6 passed |
| `multiasic_generic_updater_test.py` | 1 passed |
| `patch_sorter_test.py` | 197 passed + 79 subtests |
| `service_validator_test.py` | 2 passed |

### Isolated add / replace / remove / mixed (3 runs each)

Purpose-built one-op patches that pass YANG validation and actually exercise the sorter:

| Op | Patch target | Runs | rc | Moves | Avg time |
|---|---|---|---|---|---|
| **add** | `/asic0/LOOPBACK_INTERFACE/Loopback0\|10.99.0.1~132` | 3/3 ✅ | 0 | 1 | 4.5 s |
| **replace** | `/asic0/ACL_TABLE/DATAACL/policy_desc` | 3/3 ✅ | 0 | 1 | 4.8 s |
| **remove** | `/asic0/ACL_TABLE/DATAACL/ports/1` (leaf-list) | 3/3 ✅ | 0 | 1 | 4.7 s |
| **mixed** (add+replace+remove) | all three in one patch | 3/3 ✅ | 0 | 3 | 5.4 s |

### Real end-to-end patches (dry-run, 3 iterations each for perf-relevant ones)

| Patch | Result | Time | Moves |
|---|---|---|---|
| `100g_config.patch` | PASS | 26.3 s | 25 |
| `400g_config.patch` | PASS | 26.4 s | 25 |
| `400g_add_v2.patch` | PASS | 22.3 s | 22 |
| `queue_add.patch` | PASS | 4.5 s | 1 |
| `multi_asic.patch` | PASS | 6.1 s | 2 |
| `multi_asic_revert.patch` | PASS | 5.2 s | 0 |
| `stress.patch` (80 ops) | PASS | 16.6 s | 2 |
| `stress_revert.patch` | PASS | 5.7 s | 0 |

Prior-run functional coverage still holds:
- Real (non-dry-run) apply — 50 ACL rules: rc=0 in 7.92 s, all 50 rules in CONFIG_DB
- Real rollback of 49/50 rules: rc=0 in 6.78 s
- Multi-ASIC dry-run spanning `/asic0/` + `/asic1/`: rc=0 in 4.94 s, both namespaces validated via `extract_scope`
- Negative cases (malformed JSON, invalid op, dangling leafref, schema violation): all produce graceful rc=2, no python tracebacks
- Rollback path via `config replace`: rc=0 in 4.10 s

## Perf validation (str3-7800-lc3-1 chassis LC, asic0, SONiC.20240532.59) — parts 1-8

### Scale battery
| Scenario | Ops | Baseline | Parts 1-7 (previous run) | **Parts 1-8 (this PR head)** | Speedup vs baseline |
|---|---:|---:|---:|---:|---:|
| `scale_50_add` (3 iters) | 50 | 11.44 s | 4.78 s | **4.48 s** | **2.55×** |
| `scale_100_add` (3 iters) | 100 | 21.13 s | 5.03 s | **4.69 s** | **4.51×** |
| `scale_200_add` (3 iters) | 200 | 42.46 s | 6.07 s | **4.67 s** | **9.09×** |
| `variance_100` (5 iters) | 100 | 21.42 s | 4.92 s | **4.57 s** (σ≈0.10 s) | **4.69×** |
| `scale_500` | 500 | 171.57 s | 12.65 s | **5.48 s** | **31.3×** |
| `scale_1000` | 1000 | timeout (rc=2) | 32.40 s | **6.96 s** | **∞ (baseline never completes)** |

### Small-op benchmarks (3 iters each)
| Operation | Ops | Baseline avg | Parts 1-7 | **Parts 1-8** |
|---|---:|---:|---:|---:|
| `op_add_20` | 20 | 6.34 s | 4.07 s | **4.69 s** ✅ |
| `op_replace_20` | 20 | 6.64 s | 4.11 s | 7.89 s * |
| `op_remove_20` | 20 | 4.24 s | 4.31 s | 5.56 s * |
| `op_mixed_30` | 30 | 5.72 s | 4.04 s | 7.62 s * |

*Regenerated against live DUT config (ACL_TABLE.policy_desc + PORT.description + ACL_TABLE.ports leaf-lists) — different targets than the original synthetic fixtures. All complete cleanly, no hangs; timing delta reflects target complexity, not a regression.

### Headline
- **`scale_1000` now completes in 7.0 s** — 4.6× faster than parts 1-7's 32.4 s. Part 8's `BulkLeafListMoveGenerator` wire-up eliminates granular remove/add on leaf-list changes.
- **`scale_500` speedup vs baseline is now 31×**.
- Every scale scenario matches or improves on parts-1-7 numbers.

## Final on-chassis validation — clean-room 3-layer A/B (2026-07-30)

Independent end-to-end re-validation on a **freshly installed image with a clean 202405-shape CONFIG_DB**, measuring this PR's full stack against unmodified stock `.59` GCU. This is the strongest available evidence: nothing carried over from prior sessions — image, config, and both code states were all built from scratch.

**Environment**
- DUT: `str3-7800-lc4-1` — Arista `7800R3AK-36DM2-C36` chassis LC (broadcom-dnx, 2 ASICs), S/N `SGD232207JY`
- Image: `SONiC.20240532.59` (`release: 202405`, `branch: heads/20240532.59`, Debian 12.12, Python 3.11, kernel 6.1.0-29-2-amd64) — installed fresh for this run
- CONFIG_DB: regenerated via `config load_minigraph -y` → 703 host keys + 1353 asic0 keys, no post-branch-cut drift keys
- All measurements are `sudo config apply-patch <file> --dry-run`, 3 iterations per scenario (safe on shared testbed — nothing committed)

**States compared**

| | Contents | Source |
|---|---|---|
| **A — stock `.59`** | Unmodified `.59` GCU + stock `sonic-yang-mgmt` + stock `libyang` | extracted directly from `/host/image-20240532.59/fs.squashfs` |
| **B — this PR + #2733** | L1 `patch_sorter.py` / `gu_common.py` / `change_applier.py` / `generic_updater.py` (this PR, parts 1-8) + L2 `sonic_yang{,_ext,_path}.py` (buildimage-msft #2733) + L3 rebuilt `libyang` / `libyang-cpp` / `python3-yang` `1.0.73` debs carrying `libyang-leaf-must.patch` | this PR head + #2733 branch |

### Results

| Scenario | Ops | A — stock `.59` | B — PR #417 + #2733 | Speedup |
|---|---:|---:|---:|:---:|
| `scale_50_add` | 50 | **11.62 s** | **4.96 s** | **2.34×** |
| `scale_100_add` | 100 | **22.13 s** | **5.19 s** | **4.26×** |
| `scale_200_add` | 200 | **43.26 s** | **4.99 s** | **8.67×** |
| `op_replace_20` | 40 | **7.30 s** | **4.62 s** | **1.58×** |
| `leaflist_replace` | 2 | ✗ not supported | **4.98 s** | **new capability** |
| `op_remove_20` | 40 | n/a¹ | n/a¹ | — |

¹ Excluded on both sides: the generated patch adds 20 ACL rules then removes all 20, leaving `ACL_RULE` empty, which SONiC's ConfigDb "no empty tables" invariant rejects identically in State A and State B. Harness artifact, not a code difference — remove-op coverage is already provided by the isolated remove and `multi_asic_revert` / `stress_revert` runs above.

**Raw per-iteration timings (s)**
```
State A (stock .59)                    State B (PR #417 + #2733 L2+L3)
  scale_50_add:  12.366 11.221 11.280    scale_50_add:     5.422 4.625 4.838
  scale_100_add: 22.267 23.243 20.885    scale_100_add:    4.975 5.274 5.312
  scale_200_add: 43.215 44.032 42.546    scale_200_add:    4.953 5.082 4.949
  op_replace_20:  7.870  7.016  7.002    op_replace_20:    4.677 4.594 4.576
                                         leaflist_replace: 4.469 4.876 5.591
```

### What this confirms

1. **Reproduces the scale numbers above on independent hardware and a clean image** — `scale_50_add` 2.34× (vs 2.55× measured on lc3-1), `scale_100_add` 4.26× (vs 4.51×). Within normal chassis-to-chassis variance.
2. **State B is effectively flat across patch size** — 4.96 s @ 50 ops → 4.99 s @ 200 ops, while stock `.59` grows linearly (11.6 s → 43.3 s). This is the O(n²)→O(n) sorter win from #3831 showing up directly in wall-clock.
3. **`leaflist_replace` only works under State B.** Stock `.59` cannot process a leaf-list replace at all; the #4478 logic bundled in this PR enables it. This is a functional gain, not just a perf one.

### Merge-order proof (empirical)

The layer dependency asserted in buildimage-msft #2733 was verified by bisecting the stack on the live DUT — each layer produces a *distinct, specific* failure until the next one is added:

| Stack on DUT | Result |
|---|---|
| Stock `.59` | ✅ works (slow — this is State A) |
| Upstream `#4592`+`#4593` files on stock `.59` | ❌ `DryRunConfigWrapper.apply_change_to_config_db() takes 2 positional arguments but 3 were given` |
| This PR (parts 1-8), **no** #2733 | ❌ `type object 'SonicYang' has no attribute 'configdb_path_split'` |
| This PR + #2733 **Layer 2 only** | ❌ `'Schema_Node_Leaf' object has no attribute 'must_size'` |
| This PR + #2733 **Layer 2 + Layer 3** | ✅ `Patch applied successfully.` |

This confirms **buildimage-msft #2733 (L2 + L3) must land before or together with this PR** — merging this PR alone would break `config apply-patch` on `202405`.

Layer 3 debs were rebuilt from `sonic-buildimage/src/libyang` (patch series incl. `libyang-leaf-must.patch`) inside a `debian:12` container to match the DUT's Debian 12 / Python 3.11 runtime, producing `libyang_1.0.73_amd64.deb`, `libyang-cpp_1.0.73_amd64.deb`, and `python3-yang_1.0.73_amd64.deb`.

## MOR add-cluster scaling A/B — `test_max_mors_under_budget` (2026-07-30)

Beyond synthetic patch batteries, this PR was measured against the **real MOR add-cluster
workflow** using `test_max_mors_under_budget` from sonic-mgmt PR
[#26274](https://github.com/sonic-net/sonic-mgmt/pull/26274) (@ `c099743e`), which answers the
operationally relevant question: *how many MORs can be added inside a 30-minute budget?*

**Environment:** DUT `str3-7800-lc4-1`, testbed `vms62-t2-7800-2`, image `SONiC.20240532.59`,
budget `GCU_TIME_BUDGET_S=1800`. State A = unmodified stock `.59` GCU; State B = this PR
(parts 1-8) + buildimage-msft #2733 L2 + L3 — the same two states as the clean-room A/B above.

Six full test executions (A and B on each of three topologies), **all PASSED**, 24 measured
N-points total. Both ASICs were used to widen the range: the test enumerates MORs only from
`PORTCHANNEL_MEMBER`, so `asic1`'s 14 routed links were converted to single-member PortChannels
reusing their existing IPs / `DEVICE_NEIGHBOR` / `BGP_NEIGHBOR` rows (no fabricated peers).

### Results — `asic1`, widest measured range (N up to 14)

| N | Input ops | A: changes | A: apply | B: changes | B: apply | Change ratio | Apply speedup |
|---:|---:|---:|---:|---:|---:|---:|:---:|
| 1 | 25 | 24 | 38.85 s | 20 | 31.88 s | 1.20× | **1.22×** |
| 5 | 113 | 120 | 161.54 s | 20 | 33.25 s | 6.00× | **4.86×** |
| 8 | 179 | 192 | 249.27 s | 20 | 32.41 s | 9.60× | **7.69×** |
| 10 | 223 | 240 | 309.60 s | 20 | 32.95 s | 12.00× | **9.40×** |
| 14 | 317 | 339 | 530.33 s | 26 | 43.40 s | 13.04× | **12.22×** |
| — | empty `[]` | 0 | 10.78 s | 0 | 10.40 s | — | 1.0× (control) |

Whole-run wall clock: **State A 51 m 39 s → State B 32 m 51 s.**

### Results — `asic0`, 10 MORs (mixed 2-member + 1-member LAGs)

| N | Input ops | A: changes | A: apply | B: changes | B: apply | Change ratio | Apply speedup |
|---:|---:|---:|---:|---:|---:|---:|:---:|
| 1 | 36 | 34 | 51.51 s | 23 | 35.35 s | 1.48× | **1.46×** |
| 5 | 156 | 170 | 222.79 s | 23 | 36.24 s | 7.39× | **6.15×** |
| 8 | 238 | 265 | 341.62 s | 23 | 37.18 s | 11.52× | **9.19×** |
| 10 | 301 | 315 | 472.39 s | 32 | 50.94 s | 9.84× | **9.27×** |

Whole-run wall clock: **State A 43 m 33 s → State B 16 m 39 s.**

### Analysis

1. **The win is change-count collapse, not faster changes.** Per-change cost is *identical*
   between states (A: 1.28–1.48 s/change; B: 1.52–1.58 s/change). What changes is how many
   changes the sorter emits: State A grows ~linearly with the input patch (24 → 339 on asic1),
   State B stays nearly flat (20 → 26). On asic1 the change count was **literally unchanged at
   20 from N=1 through N=10** while the input patch grew ~9×. This is the bulk leaf-list
   generator folding per-member operations into single changes — exactly the #3831 mechanism.

2. **Marginal cost per MOR: 37.8 s → 0.89 s on asic1 (42× slope reduction);
   46.8 s → 1.73 s on asic0 (27×).** Extrapolated to the 1800 s budget: ~47 MORs (A) vs
   ~1990 MORs (B) on asic1. Flagged as extrapolation — the *measured* claim is that at N=14
   State A needs 530 s of apply time and State B needs 43 s.

3. **The speedup widens with N (1.22× → 12.22×) and is still climbing at the edge of the
   measured range.** The advantage is not a fixed constant factor; it grows with cluster size,
   which is the regime MRC isolation actually operates in.

4. **Control validates attribution.** An empty `[]` patch costs ~10.4–10.8 s in *both* states —
   pure fixed overhead (DB reads, YANG load, verification) that this PR does not touch, and does
   not regress. The measured gain is therefore attributable to the sorter, not to ambient
   differences between the two DUT states.

5. **Independent reproduction of the sonic-mgmt PR's published baseline.** Our State A numbers
   match PR #26274's published stock figures on a different image build — N=1: 34 changes /
   50.19 s (published 34 / 50.3 s); N=5: 170 changes / 217.35 s (published 170 / 232.0 s).
   This cross-validates the harness and the measurement method.

> Note on end-to-end times: each N-point includes a fixed ~186 s stall that is **not** GCU and
> **not** BGP convergence. It comes from a defect in the sonic-mgmt test's own
> `_verify_bgp_up_scaling` helper, which greps `show ip bgp summary -d all` for the string
> `"Estab"` — a string SONiC never prints (an Established session shows its *prefix count*, e.g.
> `257`, in the `State/PfxRcd` column). The match therefore always fails and always burns its full
> 180 s timeout, reporting `bgp_up=False` regardless of actual BGP health. Proven by re-running the
> identical State B sweep with all 24 IPv4 + 24 IPv6 peers genuinely Established (257 prefixes
> each): e2e changed by **less than 1 second** (222.1 → 222.2 s at N=1, 231.8 → 231.9 s at N=8).
> This is a harness defect that has now been **fixed** in sonic-net/sonic-mgmt#26274 (commit `5fd866d`:
> drop `-d all` and treat a peer as Established iff its `State/PfxRcd` column is numeric — verified on
> `str3-7800-lc4-1`, 24/24 peers detected up where the old logic found 0). It affects both states equally
> and so does not bias the A/B comparison. The apply-patch column is the PR-attributable
> measurement; e2e is reported for completeness.
>
> Reproducibility: three independent State B sweeps on identical topology gave N=1 222.1 / 222.9 /
> 222.2 s, N=5 224.4 / 224.5 / 224.0 s, N=8 231.8 / 231.6 / 231.9 s — max spread 0.8 s.

## Grand total

**536 test cases + 26 perf runs + 15 clean-room A/B runs + 24 MOR-scaling A/B data points
(6 full `test_max_mors_under_budget` executions) = 601 checks, 0 failures.**

Plus a 5-step empirical merge-order proof (see previous section) establishing that buildimage-msft #2733 Layers 2+3 are hard prerequisites for this PR.

Signed-off-by: Rithvick Reddy Munagala <rimunagala@microsoft.com>





